### PR TITLE
feat: add project identification to request tracking

### DIFF
--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -138,6 +138,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		accountUsed: string | null,
 		statusCode: number | null,
 		timestamp?: number,
+		project?: string | null,
 	): void {
 		this.requests.saveMeta(
 			id,
@@ -146,6 +147,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 			accountUsed,
 			statusCode,
 			timestamp,
+			project,
 		);
 	}
 
@@ -161,6 +163,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		failoverAttempts: number,
 		usage?: RequestData["usage"],
 		agentUsed?: string,
+		project?: string | null,
 	): void {
 		this.requests.save({
 			id,
@@ -174,6 +177,7 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 			failoverAttempts,
 			usage,
 			agentUsed,
+			project,
 		});
 	}
 

--- a/packages/database/src/migrations.ts
+++ b/packages/database/src/migrations.ts
@@ -267,6 +267,12 @@ export function runMigrations(db: Database): void {
 		log.info("Added output_tokens_per_second column to requests table");
 	}
 
+	// Add project column if it doesn't exist
+	if (!requestsColumnNames.includes("project")) {
+		db.prepare("ALTER TABLE requests ADD COLUMN project TEXT").run();
+		log.info("Added project column to requests table");
+	}
+
 	// Add performance indexes
 	addPerformanceIndexes(db);
 }

--- a/packages/database/src/performance-indexes.ts
+++ b/packages/database/src/performance-indexes.ts
@@ -108,6 +108,14 @@ export function addPerformanceIndexes(db: Database): void {
 	`);
 	log.info("Added index: idx_accounts_request_count");
 
+	// Index for project-based analytics
+	db.run(`
+		CREATE INDEX IF NOT EXISTS idx_requests_project_timestamp
+		ON requests(project, timestamp DESC)
+		WHERE project IS NOT NULL
+	`);
+	log.info("Added index: idx_requests_project_timestamp");
+
 	log.info("Performance indexes added successfully");
 }
 

--- a/packages/database/src/repositories/request.repository.ts
+++ b/packages/database/src/repositories/request.repository.ts
@@ -11,6 +11,7 @@ export interface RequestData {
 	responseTime: number;
 	failoverAttempts: number;
 	agentUsed?: string;
+	project?: string | null;
 	usage?: {
 		model?: string;
 		promptTokens?: number;
@@ -33,16 +34,17 @@ export class RequestRepository extends BaseRepository<RequestData> {
 		accountUsed: string | null,
 		statusCode: number | null,
 		timestamp?: number,
+		project?: string | null,
 	): void {
 		this.run(
 			`
 			INSERT INTO requests (
-				id, timestamp, method, path, account_used, 
-				status_code, success, error_message, response_time_ms, failover_attempts
+				id, timestamp, method, path, account_used,
+				status_code, success, error_message, response_time_ms, failover_attempts, project
 			)
-			VALUES (?, ?, ?, ?, ?, ?, 0, NULL, 0, 0)
+			VALUES (?, ?, ?, ?, ?, ?, 0, NULL, 0, 0, ?)
 		`,
-			[id, timestamp || Date.now(), method, path, accountUsed, statusCode],
+			[id, timestamp || Date.now(), method, path, accountUsed, statusCode, project || null],
 		);
 	}
 
@@ -51,13 +53,13 @@ export class RequestRepository extends BaseRepository<RequestData> {
 		this.run(
 			`
 			INSERT OR REPLACE INTO requests (
-				id, timestamp, method, path, account_used, 
+				id, timestamp, method, path, account_used,
 				status_code, success, error_message, response_time_ms, failover_attempts,
 				model, prompt_tokens, completion_tokens, total_tokens, cost_usd,
 				input_tokens, cache_read_input_tokens, cache_creation_input_tokens, output_tokens,
-				agent_used, output_tokens_per_second
+				agent_used, output_tokens_per_second, project
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`,
 			[
 				data.id,
@@ -81,6 +83,7 @@ export class RequestRepository extends BaseRepository<RequestData> {
 				usage?.outputTokens || null,
 				data.agentUsed || null,
 				usage?.tokensPerSecond || null,
+				data.project || null,
 			],
 		);
 	}

--- a/packages/proxy/src/post-processor.worker.ts
+++ b/packages/proxy/src/post-processor.worker.ts
@@ -37,6 +37,7 @@ interface RequestState {
 	};
 	lastActivity: number;
 	agentUsed?: string;
+	project?: string | null;
 	firstTokenTimestamp?: number;
 	lastTokenTimestamp?: number;
 	providerFinalOutputTokens?: number;
@@ -99,6 +100,45 @@ function _extractSystemPrompt(requestBody: string | null): string | null {
 		}
 	} catch (error) {
 		log.debug("Failed to extract system prompt:", error);
+	}
+
+	return null;
+}
+
+/**
+ * Extract project name from the request.
+ * Priority: 1) x-project header, 2) path in system prompt, 3) first heading in system prompt
+ */
+function extractProjectFromRequest(startMessage: StartMessage): string | null {
+	// Priority 1: explicit header
+	if (startMessage.requestHeaders) {
+		const headerProject =
+			startMessage.requestHeaders["x-project"] ||
+			startMessage.requestHeaders["X-Project"];
+		if (headerProject) return headerProject;
+	}
+
+	// Priority 2 & 3: parse from system prompt
+	const systemPrompt = _extractSystemPrompt(startMessage.requestBody);
+	if (!systemPrompt) return null;
+
+	// Try path patterns: /Users/.../Desktop/ProjectName/ or /home/.../ProjectName/
+	const pathMatch = systemPrompt.match(
+		/\/(?:Users|home)\/[^/]+\/(?:Desktop|projects|repos|src)\/([^/]+)\//,
+	);
+	if (pathMatch) return pathMatch[1];
+
+	// Try CLAUDE.md-style heading: "# ProjectName"
+	const headingMatch = systemPrompt.match(/^#\s+(.+?)$/m);
+	if (headingMatch) {
+		const heading = headingMatch[1].trim();
+		// Skip generic headings
+		if (
+			!heading.toLowerCase().startsWith("claude") &&
+			heading.length < 60
+		) {
+			return heading;
+		}
 	}
 
 	return null;
@@ -282,6 +322,12 @@ async function handleStart(msg: StartMessage): Promise<void> {
 		log.debug(`Agent '${msg.agentUsed}' used for request ${msg.requestId}`);
 	}
 
+	// Extract project from request headers or system prompt
+	state.project = extractProjectFromRequest(msg);
+	if (state.project) {
+		log.debug(`Project '${state.project}' detected for request ${msg.requestId}`);
+	}
+
 	requests.set(msg.requestId, state);
 
 	// Skip all database operations for ignored requests
@@ -299,6 +345,7 @@ async function handleStart(msg: StartMessage): Promise<void> {
 			msg.accountId,
 			msg.responseStatus,
 			msg.timestamp,
+			state.project,
 		),
 	);
 
@@ -425,6 +472,7 @@ async function handleEnd(msg: EndMessage): Promise<void> {
 					}
 				: undefined,
 			state.agentUsed,
+			state.project,
 		),
 	);
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -4,6 +4,7 @@ export interface RequestMeta {
 	path: string;
 	timestamp: number;
 	agentUsed?: string | null;
+	project?: string | null;
 }
 
 export interface AgentUpdatePayload {

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -21,6 +21,7 @@ export interface RequestRow {
 	output_tokens: number | null;
 	agent_used: string | null;
 	output_tokens_per_second: number | null;
+	project: string | null;
 }
 
 // Domain model
@@ -46,6 +47,7 @@ export interface Request {
 	outputTokens?: number;
 	agentUsed?: string;
 	tokensPerSecond?: number;
+	project?: string;
 }
 
 // API response type
@@ -71,6 +73,7 @@ export interface RequestResponse {
 	costUsd?: number;
 	agentUsed?: string;
 	tokensPerSecond?: number;
+	project?: string;
 }
 
 // Detailed request with payload
@@ -125,6 +128,7 @@ export function toRequest(row: RequestRow): Request {
 		outputTokens: row.output_tokens || undefined,
 		agentUsed: row.agent_used || undefined,
 		tokensPerSecond: row.output_tokens_per_second || undefined,
+		project: row.project || undefined,
 	};
 }
 
@@ -151,6 +155,7 @@ export function toRequestResponse(request: Request): RequestResponse {
 		costUsd: request.costUsd,
 		agentUsed: request.agentUsed,
 		tokensPerSecond: request.tokensPerSecond,
+		project: request.project,
 	};
 }
 


### PR DESCRIPTION
## Summary

- Extracts project name from Claude API requests to tag each proxied request with its originating project
- Uses a 3-tier extraction strategy: `x-project` header > system prompt path pattern > system prompt heading
- Adds `project` column to requests table with migration guard and performance index
- Fully backward-compatible — project defaults to null for existing requests

## Motivation

When ccflare proxies traffic from multiple Claude Code projects across multiple machines, there's no way to tell which project generated which request. This makes per-project analytics, cost tracking, and session correlation impossible.

## Changes

| File | Change |
|------|--------|
| `packages/types/src/api.ts` | Add `project` to `RequestMeta` |
| `packages/types/src/request.ts` | Add `project` to `RequestRow`, `Request`, `RequestResponse` + mappers |
| `packages/proxy/src/post-processor.worker.ts` | Add `extractProjectFromRequest()`, wire through `handleStart`/`handleEnd` |
| `packages/database/src/repositories/request.repository.ts` | Add `project` to `RequestData`, `saveMeta()`, `save()` |
| `packages/database/src/database-operations.ts` | Thread `project` param through facade methods |
| `packages/database/src/migrations.ts` | `ALTER TABLE ADD COLUMN project TEXT` |
| `packages/database/src/performance-indexes.ts` | Add `idx_requests_project_timestamp` |

## Test plan

- [ ] Build passes: `bun run build`
- [ ] Start server, make a Claude API call from a project with CLAUDE.md
- [ ] Verify `project` column populated: `sqlite3 ccflare.db "SELECT id, project FROM requests LIMIT 5"`
- [ ] Verify `x-project` header override: `curl -H "x-project: test" ...`
- [ ] Verify null project for requests without system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)