### PR TITLE
feat(kimi): add Kimi Code provider and list-price costing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ ccflare proxies requests by provider prefix:
 
 - `http://localhost:8080/v1/anthropic/*`
 - `http://localhost:8080/v1/openai/*`
+- `http://localhost:8080/v1/kimi/*`
 - `http://localhost:8080/v1/ccflare/*`
 
 Examples:
@@ -48,6 +49,7 @@ Examples:
 - `/v1/anthropic/v1/messages` → `https://api.anthropic.com/v1/messages`
 - `/v1/openai/chat/completions` → `https://api.openai.com/v1/chat/completions`
 - `/v1/openai/responses` → `https://api.openai.com/v1/responses`
+- `/v1/kimi/chat/completions` → `https://api.kimi.com/coding/v1/chat/completions`
 
 The `/v1/{provider}` prefix is stripped exactly once before forwarding upstream.
 

--- a/apps/tui/src/core/accounts.ts
+++ b/apps/tui/src/core/accounts.ts
@@ -12,6 +12,7 @@ import {
 	type AuthMethod,
 	getProviderAuthMethod,
 	getProviderDisplayLabel,
+	isDeviceCodeProvider,
 	type OAuthProvider,
 } from "@ccflare/types";
 import type { AccountDisplay } from "@ccflare/ui";
@@ -107,16 +108,21 @@ export async function submitAddAccount(
 		return;
 	}
 
-	if (!flowData || !code) {
+	const deviceGrant = isDeviceCodeProvider(provider);
+	if (!flowData || (!code && !deviceGrant)) {
 		throw new Error("Authorization code is required for OAuth providers.");
 	}
 
 	const config = new Config();
 	const oauthFlow = await createOAuthFlow(dbOps, config);
 
-	console.log("\nExchanging code for tokens...");
+	console.log(
+		deviceGrant
+			? "\nWaiting for you to approve in the browser..."
+			: "\nExchanging code for tokens...",
+	);
 	await oauthFlow.complete(
-		{ sessionId: flowData.sessionId, code, name },
+		{ sessionId: flowData.sessionId, code: code ?? "", name },
 		flowData,
 	);
 

--- a/apps/tui/src/core/cli/commands/account.ts
+++ b/apps/tui/src/core/cli/commands/account.ts
@@ -7,6 +7,7 @@ import {
 	getProviderAuthMethod,
 	getProviderDisplayLabel,
 	isAccountProvider,
+	isDeviceCodeProvider,
 } from "@ccflare/types";
 import { type AccountDisplay, toAccountDisplay } from "@ccflare/ui";
 import type { PromptAdapter } from "../prompts/adapter";
@@ -89,9 +90,9 @@ export async function addAccount(
 		name,
 		provider,
 	});
-	const { authUrl, sessionId } = flowResult;
+	const { authUrl, sessionId, userCode } = flowResult;
 
-	// Open browser and prompt for code
+	// Open browser to authenticate
 	console.log(`\nOpening browser to authenticate...`);
 	console.log(`URL: ${authUrl}`);
 	const browserOpened = await openBrowser(authUrl);
@@ -101,11 +102,19 @@ export async function addAccount(
 		);
 	}
 
-	// Get authorization code
-	const code = await adapter.input("\nEnter the authorization code: ");
-
-	// Complete OAuth flow
-	console.log("\nExchanging code for tokens...");
+	// Device-grant providers return no code to paste: approve in the browser
+	// and the token endpoint is polled until it hands over tokens.
+	const deviceGrant = isDeviceCodeProvider(provider);
+	let code = "";
+	if (deviceGrant) {
+		if (userCode) {
+			console.log(`\nVerification code: ${userCode}`);
+		}
+		console.log("\nWaiting for you to approve in the browser...");
+	} else {
+		code = await adapter.input("\nEnter the authorization code: ");
+		console.log("\nExchanging code for tokens...");
+	}
 	const _account = await oauthFlow.complete(
 		{ sessionId, code, name },
 		flowResult,

--- a/apps/web/src/components/accounts/AccountAddForm.tsx
+++ b/apps/web/src/components/accounts/AccountAddForm.tsx
@@ -4,6 +4,7 @@ import {
 	type ApiKeyProvider,
 	type AuthSessionStatus,
 	isApiKeyProvider,
+	isDeviceCodeProvider,
 	isOAuthProvider,
 	type OAuthProvider,
 } from "@ccflare/types";
@@ -69,6 +70,11 @@ export function AccountAddForm({
 	const selectedOAuthProvider = isOAuthProvider(newAccount.provider)
 		? newAccount.provider
 		: null;
+	// Device-grant providers (e.g. Kimi) never show the user a code: the server
+	// polls the token endpoint after the user approves in the browser.
+	const isDeviceGrant =
+		selectedOAuthProvider !== null &&
+		isDeviceCodeProvider(selectedOAuthProvider);
 
 	const resetForm = useCallback(() => {
 		setAuthStep("form");
@@ -174,6 +180,23 @@ export function AccountAddForm({
 			}
 
 			setAuthStep("waiting");
+
+			// Device grant: nothing comes back from the browser, so ask the server
+			// to start polling now. Success is picked up by the status poll above;
+			// only failures need surfacing here.
+			if (isDeviceCodeProvider(selectedOAuthProvider)) {
+				void onCompleteOAuth({
+					provider: selectedOAuthProvider,
+					sessionId,
+					code: "",
+				}).catch((error: unknown) => {
+					onError(
+						error instanceof Error
+							? error.message
+							: "Failed to complete authorization",
+					);
+				});
+			}
 			return;
 		}
 	};
@@ -279,8 +302,10 @@ export function AccountAddForm({
 						<div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
 							This provider uses OAuth. Click{" "}
 							<span className="font-medium text-foreground">Start OAuth</span>{" "}
-							to open the authorization flow in a new tab. ccflare will detect
-							completion automatically.
+							to open the authorization flow in a new tab.{" "}
+							{isDeviceGrant
+								? "Approve the device authorization there; there is no code to paste."
+								: "ccflare will detect completion automatically."}
 						</div>
 					)}
 				</>
@@ -301,8 +326,11 @@ export function AccountAddForm({
 							A new browser tab has opened for authentication. Finish the
 							provider sign-in flow and this page will update automatically
 							every 2 seconds.
+							{isDeviceGrant
+								? " This provider has no code to paste: just approve the device authorization in the new tab."
+								: ""}
 						</p>
-						<div className="space-y-2">
+						<div className={isDeviceGrant ? "hidden" : "space-y-2"}>
 							<Label htmlFor="authorization-code">Authorization Code</Label>
 							<Input
 								id="authorization-code"
@@ -331,14 +359,16 @@ export function AccountAddForm({
 						)}
 					</div>
 					<div className="flex gap-2">
-						<Button
-							onClick={() => {
-								void handleCompleteOAuth();
-							}}
-							disabled={isCompletingOAuth || !authorizationCode.trim()}
-						>
-							{isCompletingOAuth ? "Completing..." : "Submit Code"}
-						</Button>
+						{!isDeviceGrant && (
+							<Button
+								onClick={() => {
+									void handleCompleteOAuth();
+								}}
+								disabled={isCompletingOAuth || !authorizationCode.trim()}
+							>
+								{isCompletingOAuth ? "Completing..." : "Submit Code"}
+							</Button>
+						)}
 						<Button variant="outline" onClick={handleCancel}>
 							Cancel
 						</Button>

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -20,6 +20,7 @@ ccflare’s provider layer gives the rest of the system a consistent way to deal
 - `openai`
 - `claude-code`
 - `codex`
+- `kimi`
 
 These are exposed through `/v1/{provider}/...` routes.
 
@@ -81,8 +82,26 @@ These use `api_key` accounts and do not depend on refresh-token flows.
 
 - `claude-code`
 - `codex`
+- `kimi`
 
 These use provider-specific OAuth adapters plus the shared OAuth flow package. Access tokens may be refreshed automatically during forwarding.
+
+### OAuth Grants
+
+Provider metadata records an `oauthGrant` so onboarding code can branch without
+importing provider classes:
+
+- `authorization_code` (`claude-code`, `codex`) — the user opens a redirect URL
+  and an authorization code comes back.
+- `device_code` (`kimi`) — the user approves at a verification URL and there is
+  **no code to paste**; ccflare polls the token endpoint instead.
+
+For device-grant providers `OAuthFlow.begin()` calls the provider's
+`beginDeviceAuthorization()` instead of generating PKCE, stores the device code
+in the existing session `verifier` slot, and returns the verification URL as
+`authUrl` plus a `userCode` for display. `complete()` is then called with an
+empty `code`; the provider's `exchangeCode()` polls until the authorization is
+approved, denied, or expires.
 
 ## OAuth Flow Integration
 
@@ -161,6 +180,36 @@ That includes:
 
 Heavy stream/websocket aggregation still happens in the proxy worker, but provider modules own the provider-specific parsing rules.
 
+## Request Cost
+
+ccflare stores a `costUsd` per request. It has one price source: the models.dev
+catalogue (`https://models.dev/api.json`), fetched by `@ccflare/core`'s pricing
+module, cached on disk under the temp directory, and refreshed every 24h
+(`CF_PRICING_REFRESH_HOURS`). No rates are hardcoded in this repo.
+
+Costs are **list-price equivalents, not billed amounts.** OAuth subscription
+accounts bill a flat rate, so the recorded number answers "what would this
+traffic have cost at metered prices," which is what makes providers comparable
+in analytics.
+
+The catalogue is keyed by provider, so the lookup needs to know which block to
+read. `packages/types/src/pricing-catalogue.ts` maps each ccflare provider to:
+
+- the catalogue blocks to consult first, because the same model id is listed by
+  many resellers at different rates and object key order is not a pricing
+  decision — `claude-code` reads `anthropic`, `codex` reads `openai`, `kimi`
+  reads `moonshotai`
+- model id aliases, for plans that publish their own ids
+
+Kimi Code needs the aliases. Its plan ids are listed under a `kimi-for-coding`
+catalogue block at zero cost because the plan is flat-rate, so they are aliased
+onto Moonshot's metered ids (`kimi-for-coding` → `kimi-k2.7-code`,
+`kimi-for-coding-highspeed` → `kimi-k2.7-code-highspeed`, `k3` and `k3-256k` →
+`kimi-k3`). Claude Code and Codex need no aliases: their model ids already match
+the first-party Anthropic and OpenAI entries.
+
+A model id absent from the catalogue logs one warning and records a cost of 0.
+
 ## Built-In Provider Notes
 
 ### Anthropic
@@ -186,6 +235,18 @@ Heavy stream/websocket aggregation still happens in the proxy worker, but provid
 - OAuth-based provider
 - Codex-specific backend route handling
 - custom headers and rate-limit parsing
+
+### Kimi
+
+- OAuth-based provider using the device authorization grant
+- upstream base URL defaults to `https://api.kimi.com/coding/v1`
+- OpenAI-compatible chat-completions upstream, so URL building, rate-limit
+  parsing and usage extraction are inherited from the OpenAI provider
+- access tokens are short-lived (900s), so refresh happens frequently and the
+  refresh token is rotated on each refresh
+- plan model ids are aliased onto Moonshot's metered ids for costing; see
+  [Request Cost](#request-cost)
+- quota fetching is not implemented yet
 
 ## Adding a New Provider
 

--- a/packages/api/src/handlers/oauth.ts
+++ b/packages/api/src/handlers/oauth.ts
@@ -19,6 +19,7 @@ import {
 	type AuthCompleteData,
 	type AuthInitData,
 	isAccountProvider,
+	isDeviceCodeProvider,
 	type MutationResult,
 } from "@ccflare/types";
 import { parseJsonObject } from "../utils/json";
@@ -272,12 +273,16 @@ export function createAuthCompleteHandler(dbOps: DatabaseOperations) {
 				return errorResponse(BadRequest("Session ID is required"));
 			}
 
-			// Validate code
-			const code = validateString(body.code, "code", {
-				required: true,
-				minLength: 1,
-			});
-			if (!code) {
+			// Device-grant providers never produce a code for the user to send;
+			// completion polls the token endpoint with the stored device code.
+			const deviceGrant = isDeviceCodeProvider(validatedProvider);
+			const code = deviceGrant
+				? ""
+				: validateString(body.code, "code", {
+						required: true,
+						minLength: 1,
+					});
+			if (!deviceGrant && !code) {
 				return errorResponse(BadRequest("Authorization code is required"));
 			}
 
@@ -294,9 +299,29 @@ export function createAuthCompleteHandler(dbOps: DatabaseOperations) {
 				const config = new Config();
 				const oauthFlow = await createOAuthFlow(dbOps, config);
 
+				// Device grants poll the token endpoint until the user approves in
+				// the browser, which routinely outlasts an HTTP request. Run it in
+				// the background and let the caller watch the auth session status;
+				// drop the session on failure so the status flips off "pending".
+				if (deviceGrant) {
+					void oauthFlow
+						.complete({ sessionId, code: "", name })
+						.catch((error: unknown) => {
+							log.error(`Device authorization failed for '${name}':`, error);
+							dbOps.deleteAuthSession(sessionId);
+						});
+
+					const pending: MutationResult<AuthCompleteData> = {
+						success: true,
+						message: `Waiting for '${name}' to be approved in the browser`,
+						data: { provider: validatedProvider },
+					};
+					return jsonResponse(pending);
+				}
+
 				await oauthFlow.complete({
 					sessionId,
-					code,
+					code: code ?? "",
 					name,
 				});
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export * from "./lifecycle";
 export { getModelShortName } from "./models";
 export {
 	estimateCostUSD,
+	resetPricingCatalogue,
 	setPricingLogger,
 	type TokenBreakdown,
 } from "./pricing";

--- a/packages/core/src/pricing.test.ts
+++ b/packages/core/src/pricing.test.ts
@@ -1,10 +1,26 @@
-import { afterEach, describe, expect, it } from "bun:test";
-import { estimateCostUSD } from "./pricing";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { estimateCostUSD, resetPricingCatalogue } from "./pricing";
 
 const originalFetch = globalThis.fetch;
 
+function stubCatalogue(catalogue: unknown): void {
+	globalThis.fetch = Object.assign(
+		async () =>
+			new Response(JSON.stringify(catalogue), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		{ preconnect: originalFetch.preconnect },
+	) as typeof fetch;
+}
+
+beforeEach(() => {
+	resetPricingCatalogue();
+});
+
 afterEach(() => {
 	globalThis.fetch = originalFetch;
+	resetPricingCatalogue();
 });
 
 describe("estimateCostUSD", () => {
@@ -45,5 +61,88 @@ describe("estimateCostUSD", () => {
 			(127 * 2.5 + 18_688 * 1.25 + 431 * 10) / 1_000_000,
 			10,
 		);
+	});
+
+	it("prices Kimi subscription model ids at their metered Moonshot rates", async () => {
+		stubCatalogue({
+			"kimi-for-coding": {
+				models: {
+					k3: {
+						id: "k3",
+						name: "Kimi K3",
+						cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+					},
+				},
+			},
+			moonshotai: {
+				models: {
+					"kimi-k3": {
+						id: "kimi-k3",
+						name: "Kimi K3",
+						cost: { input: 3, output: 15, cache_read: 0.3 },
+					},
+				},
+			},
+		});
+
+		await expect(
+			estimateCostUSD(
+				"k3",
+				{ inputTokens: 1_000, cacheReadInputTokens: 4_000, outputTokens: 200 },
+				{ provider: "kimi" },
+			),
+		).resolves.toBeCloseTo(
+			(1_000 * 3 + 4_000 * 0.3 + 200 * 15) / 1_000_000,
+			10,
+		);
+	});
+
+	it("prefers the first-party catalogue block when resellers list the same id", async () => {
+		stubCatalogue({
+			reseller: {
+				models: {
+					"gpt-5.3-codex": {
+						id: "gpt-5.3-codex",
+						name: "Reseller markup",
+						cost: { input: 99, output: 99 },
+					},
+				},
+			},
+			openai: {
+				models: {
+					"gpt-5.3-codex": {
+						id: "gpt-5.3-codex",
+						name: "GPT-5.3 Codex",
+						cost: { input: 1.75, output: 14, cache_read: 0.175 },
+					},
+				},
+			},
+		});
+
+		await expect(
+			estimateCostUSD(
+				"gpt-5.3-codex",
+				{ inputTokens: 1_000, outputTokens: 100 },
+				{ provider: "codex" },
+			),
+		).resolves.toBeCloseTo((1_000 * 1.75 + 100 * 14) / 1_000_000, 10);
+	});
+
+	it("falls back to a catalogue-wide scan without a provider hint", async () => {
+		stubCatalogue({
+			moonshotai: {
+				models: {
+					"kimi-k3": {
+						id: "kimi-k3",
+						name: "Kimi K3",
+						cost: { input: 3, output: 15 },
+					},
+				},
+			},
+		});
+
+		await expect(
+			estimateCostUSD("kimi-k3", { inputTokens: 1_000, outputTokens: 100 }),
+		).resolves.toBeCloseTo((1_000 * 3 + 100 * 15) / 1_000_000, 10);
 	});
 });

--- a/packages/core/src/pricing.ts
+++ b/packages/core/src/pricing.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolvePricingCatalogueLookup } from "@ccflare/types";
 import { TIME_CONSTANTS } from "./constants";
 
 export interface TokenBreakdown {
@@ -144,6 +145,12 @@ class PriceCatalogue {
 		return data;
 	}
 
+	reset(): void {
+		this.priceData = null;
+		this.lastFetch = 0;
+		this.warnedModels.clear();
+	}
+
 	warnOnce(modelId: string): void {
 		if (!this.warnedModels.has(modelId)) {
 			this.warnedModels.add(modelId);
@@ -162,10 +169,36 @@ export function setPricingLogger(logger: Logger): void {
 	PriceCatalogue.get().setLogger(logger);
 }
 
+/**
+ * Drop the in-memory catalogue so the next estimate refetches.
+ *
+ * The catalogue is a process-wide singleton with a 24h memory cache, which
+ * tests would otherwise carry between cases.
+ */
+export function resetPricingCatalogue(): void {
+	PriceCatalogue.get().reset();
+}
+
+/**
+ * Look up a model's rates, preferring the named catalogue blocks.
+ *
+ * The catalogue lists the same model id under many resellers at different
+ * rates, and object key order is not a pricing decision, so the provider's
+ * first-party blocks are consulted first. The catalogue-wide scan remains as a
+ * fallback for ids ccflare has no provider hint for.
+ */
 function findModelCost(
 	pricing: ApiResponse,
 	modelId: string,
+	preferredCatalogues: readonly string[] = [],
 ): ModelCost | null {
+	for (const catalogue of preferredCatalogues) {
+		const model = pricing[catalogue]?.models?.[modelId];
+		if (model?.cost) {
+			return model.cost;
+		}
+	}
+
 	for (const provider of Object.values(pricing)) {
 		const model = provider.models?.[modelId];
 		if (model?.cost) {
@@ -176,12 +209,19 @@ function findModelCost(
 }
 
 /**
- * Estimate the total cost in USD for a request based on token counts
+ * Estimate the total cost in USD for a request based on token counts.
+ *
+ * Passing the account provider that served the request lets subscription model
+ * ids resolve to their metered equivalent and keeps ambiguous ids on the
+ * first-party catalogue block. Costs are list-price equivalents, not billed
+ * amounts: a flat-rate subscription account bills nothing per request.
+ *
  * @returns Cost in dollars (NOT per million)
  */
 export async function estimateCostUSD(
 	modelId: string,
 	tokens: TokenBreakdown,
+	options: { provider?: string } = {},
 ): Promise<number> {
 	const catalogue = PriceCatalogue.get();
 
@@ -192,11 +232,13 @@ export async function estimateCostUSD(
 			throw new Error("Model id is empty");
 		}
 
-		const cost = findModelCost(pricing, normalizedModelId);
+		const lookup = resolvePricingCatalogueLookup(
+			normalizedModelId,
+			options.provider,
+		);
+		const cost = findModelCost(pricing, lookup.modelId, lookup.catalogues);
 		if (!cost) {
-			throw new Error(
-				`Model ${normalizedModelId} not found in pricing catalogue`,
-			);
+			throw new Error(`Model ${lookup.modelId} not found in pricing catalogue`);
 		}
 
 		let totalCost = 0;

--- a/packages/oauth-flow/src/index.test.ts
+++ b/packages/oauth-flow/src/index.test.ts
@@ -191,4 +191,50 @@ describe("OAuthFlow", () => {
 			}),
 		);
 	});
+	it("begins a Kimi device flow without PKCE and stores the device code", async () => {
+		const { config, dbOps } = createTestContext();
+		const oauthFlow = await createOAuthFlow(dbOps, config);
+
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = new Request(input, init);
+				expect(request.url).toBe(
+					"https://auth.kimi.com/api/oauth/device_authorization",
+				);
+
+				return new Response(
+					JSON.stringify({
+						device_code: "kimi-device-code",
+						user_code: "ABCD-1234",
+						verification_uri: "https://www.kimi.com/code/authorize_device",
+						verification_uri_complete:
+							"https://www.kimi.com/code/authorize_device?user_code=ABCD-1234",
+						expires_in: 1800,
+						interval: 5,
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			},
+			{ preconnect: originalFetch.preconnect },
+		) as typeof fetch;
+
+		const result = await oauthFlow.begin({
+			name: "kimi-device-account",
+			provider: "kimi",
+		});
+
+		expect(result.authUrl).toBe(
+			"https://www.kimi.com/code/authorize_device?user_code=ABCD-1234",
+		);
+		expect(result.userCode).toBe("ABCD-1234");
+		expect(result.pkce.verifier).toBe("kimi-device-code");
+		expect(
+			JSON.parse(dbOps.getAuthSession(result.sessionId)?.stateJson ?? "{}"),
+		).toEqual(
+			expect.objectContaining({
+				verifier: "kimi-device-code",
+				status: "pending",
+			}),
+		);
+	});
 });

--- a/packages/oauth-flow/src/index.ts
+++ b/packages/oauth-flow/src/index.ts
@@ -58,10 +58,19 @@ export interface BeginResult {
 	authUrl: string;
 	pkce: PKCEChallenge;
 	oauthConfig: OAuthProviderConfig;
+	/**
+	 * Device-grant providers only: the short code the user confirms in the
+	 * browser. Present so UIs can display it alongside the verification URL.
+	 */
+	userCode?: string;
 }
 
 export interface CompleteOptions {
 	sessionId: string;
+	/**
+	 * Authorization code. Empty for device-grant providers, which poll the
+	 * token endpoint with the stored device code instead.
+	 */
 	code: string;
 	name?: string;
 }
@@ -108,15 +117,48 @@ export class OAuthFlow {
 		// Get OAuth provider
 		const oauthProvider = getOAuthProviderForFlow(provider);
 
-		// Generate PKCE challenge
-		const pkce = await generatePKCE();
-
 		// Get OAuth config with provider-specific client ID handling
 		const oauthConfig = getOAuthConfigForFlow(
 			provider,
 			this.config,
 			oauthProvider,
 		);
+
+		// Device-grant providers (e.g. Kimi) have no redirect and no PKCE: the
+		// device code takes the verifier slot and is polled in complete().
+		if (oauthProvider.beginDeviceAuthorization) {
+			const device = await oauthProvider.beginDeviceAuthorization(oauthConfig);
+			const pkce: PKCEChallenge = {
+				verifier: device.deviceCode,
+				challenge: "",
+			};
+			const sessionState: SessionState = {
+				verifier: device.deviceCode,
+				// No redirect callback matches on state here, but the column is
+				// required and must stay unique across sessions.
+				state: crypto.randomUUID(),
+				status: "pending",
+			};
+
+			const sessionId = this.dbOps.createAuthSession(
+				provider,
+				"oauth",
+				name,
+				JSON.stringify(sessionState),
+				device.expiresAt,
+			);
+
+			return {
+				sessionId,
+				authUrl: device.verificationUriComplete,
+				pkce,
+				oauthConfig,
+				userCode: device.userCode,
+			};
+		}
+
+		// Generate PKCE challenge
+		const pkce = await generatePKCE();
 
 		// Generate auth URL
 		const authUrl = oauthProvider.generateAuthUrl(oauthConfig, pkce);

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -8,6 +8,7 @@ describe("built-in providers", () => {
 			"openai",
 			"claude-code",
 			"codex",
+			"kimi",
 		]);
 	});
 

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -20,6 +20,7 @@ export * from "./types";
 import { AnthropicProvider } from "./providers/anthropic/provider";
 import { ClaudeCodeProvider } from "./providers/claude-code/provider";
 import { CodexProvider } from "./providers/codex/provider";
+import { KimiProvider } from "./providers/kimi/provider";
 import { OpenAIProvider } from "./providers/openai/provider";
 // Auto-register built-in providers
 import { registerProvider } from "./registry";
@@ -28,3 +29,4 @@ registerProvider(new AnthropicProvider());
 registerProvider(new OpenAIProvider());
 registerProvider(new ClaudeCodeProvider());
 registerProvider(new CodexProvider());
+registerProvider(new KimiProvider());

--- a/packages/providers/src/providers/index.ts
+++ b/packages/providers/src/providers/index.ts
@@ -17,4 +17,13 @@ export {
 	CodexOAuthProvider,
 	CodexProvider,
 } from "./codex/index";
+export {
+	KIMI_DEVICE_GRANT_TYPE,
+	KIMI_OAUTH_CLIENT_ID,
+	KIMI_OAUTH_DEVICE_AUTHORIZATION_URL,
+	KIMI_OAUTH_HOST,
+	KIMI_OAUTH_TOKEN_URL,
+	KimiOAuthProvider,
+	KimiProvider,
+} from "./kimi/index";
 export { OpenAIOAuthProvider, OpenAIProvider } from "./openai/index";

--- a/packages/providers/src/providers/kimi/index.ts
+++ b/packages/providers/src/providers/kimi/index.ts
@@ -1,0 +1,9 @@
+export {
+	KIMI_DEVICE_GRANT_TYPE,
+	KIMI_OAUTH_CLIENT_ID,
+	KIMI_OAUTH_DEVICE_AUTHORIZATION_URL,
+	KIMI_OAUTH_HOST,
+	KIMI_OAUTH_TOKEN_URL,
+	KimiOAuthProvider,
+} from "./oauth";
+export { KimiProvider } from "./provider";

--- a/packages/providers/src/providers/kimi/oauth.test.ts
+++ b/packages/providers/src/providers/kimi/oauth.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	KIMI_OAUTH_CLIENT_ID,
+	KIMI_OAUTH_DEVICE_AUTHORIZATION_URL,
+	KIMI_OAUTH_TOKEN_URL,
+	KimiOAuthProvider,
+} from "./oauth";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(
+	handler: (request: Request) => Promise<Response> | Response,
+): void {
+	globalThis.fetch = Object.assign(
+		async (input: RequestInfo | URL, init?: RequestInit) =>
+			handler(new Request(input, init)),
+		{ preconnect: originalFetch.preconnect },
+	) as typeof fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("KimiOAuthProvider", () => {
+	it("requests a device authorization and returns the verification URL", async () => {
+		const provider = new KimiOAuthProvider();
+		mockFetch(async (request) => {
+			expect(request.url).toBe(KIMI_OAUTH_DEVICE_AUTHORIZATION_URL);
+			expect(await request.text()).toBe(`client_id=${KIMI_OAUTH_CLIENT_ID}`);
+			return jsonResponse({
+				device_code: "device-code-1",
+				user_code: "ABCD-1234",
+				verification_uri: "https://www.kimi.com/code/authorize_device",
+				verification_uri_complete:
+					"https://www.kimi.com/code/authorize_device?user_code=ABCD-1234",
+				expires_in: 1800,
+				interval: 5,
+			});
+		});
+
+		const device = await provider.beginDeviceAuthorization(
+			provider.getOAuthConfig(),
+		);
+
+		expect(device.deviceCode).toBe("device-code-1");
+		expect(device.userCode).toBe("ABCD-1234");
+		expect(device.verificationUriComplete).toContain("user_code=ABCD-1234");
+		expect(device.interval).toBe(5);
+		expect(device.expiresAt).toBeGreaterThan(Date.now());
+	});
+
+	it("polls the token endpoint past authorization_pending until tokens arrive", async () => {
+		const provider = new KimiOAuthProvider(1);
+		let calls = 0;
+		mockFetch(async (request) => {
+			calls += 1;
+			expect(request.url).toBe(KIMI_OAUTH_TOKEN_URL);
+			const body = await request.text();
+			expect(body).toContain("device_code=device-code-1");
+			expect(body).toContain(
+				"grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code",
+			);
+
+			if (calls === 1) {
+				return jsonResponse({ error: "authorization_pending" }, 400);
+			}
+			return jsonResponse({
+				access_token: "kimi-access",
+				refresh_token: "kimi-refresh",
+				expires_in: 900,
+			});
+		});
+
+		const tokens = await provider.exchangeCode(
+			"",
+			"device-code-1",
+			provider.getOAuthConfig(),
+		);
+
+		expect(calls).toBe(2);
+		expect(tokens.accessToken).toBe("kimi-access");
+		expect(tokens.refreshToken).toBe("kimi-refresh");
+		expect(tokens.expiresAt).toBeGreaterThan(Date.now());
+	});
+
+	it("fails fast when the device authorization is denied", async () => {
+		const provider = new KimiOAuthProvider(1);
+		mockFetch(() => jsonResponse({ error: "access_denied" }, 400));
+
+		await expect(
+			provider.exchangeCode("", "device-code-1", provider.getOAuthConfig()),
+		).rejects.toThrow(/denied/i);
+	});
+});

--- a/packages/providers/src/providers/kimi/oauth.ts
+++ b/packages/providers/src/providers/kimi/oauth.ts
@@ -1,0 +1,215 @@
+import { OAuthError } from "@ccflare/core";
+import type {
+	DeviceAuthorization,
+	OAuthProvider,
+	OAuthProviderConfig,
+	TokenResult,
+} from "../../types";
+
+export const KIMI_OAUTH_HOST = "https://auth.kimi.com";
+export const KIMI_OAUTH_DEVICE_AUTHORIZATION_URL = `${KIMI_OAUTH_HOST}/api/oauth/device_authorization`;
+export const KIMI_OAUTH_TOKEN_URL = `${KIMI_OAUTH_HOST}/api/oauth/token`;
+export const KIMI_OAUTH_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
+export const KIMI_DEVICE_GRANT_TYPE =
+	"urn:ietf:params:oauth:grant-type:device_code";
+
+/** Fallback poll interval when the authorization server omits one. */
+const DEFAULT_POLL_INTERVAL_SECONDS = 5;
+/**
+ * Upper bound on a single `exchangeCode` poll loop. The device code itself is
+ * valid for 30 minutes, but `complete` is called from an HTTP handler, so the
+ * loop is capped well below any sane request timeout.
+ */
+const MAX_POLL_DURATION_MS = 5 * 60 * 1000;
+
+interface DeviceAuthorizationResponse {
+	device_code?: string;
+	user_code?: string;
+	verification_uri?: string;
+	verification_uri_complete?: string;
+	expires_in?: number;
+	interval?: number;
+}
+
+interface TokenResponse {
+	access_token?: string;
+	refresh_token?: string;
+	expires_in?: number;
+	expires_at?: number;
+	error?: string;
+	error_description?: string;
+}
+
+async function postForm(
+	url: string,
+	body: Record<string, string>,
+): Promise<{ status: number; json: Record<string, unknown> }> {
+	const response = await fetch(url, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams(body).toString(),
+	});
+
+	let json: Record<string, unknown> = {};
+	try {
+		json = (await response.json()) as Record<string, unknown>;
+	} catch {
+		// Non-JSON payloads surface via the status code alone.
+	}
+
+	return { status: response.status, json };
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Kimi Code OAuth, which uses the device authorization grant rather than a
+ * redirect + PKCE exchange. The user approves in a browser and the token
+ * endpoint is polled until it returns tokens; nothing is pasted back.
+ */
+export class KimiOAuthProvider implements OAuthProvider {
+	/**
+	 * `pollIntervalMs` is overridable so tests do not wait real seconds. The
+	 * server's advertised interval is not plumbed through `exchangeCode`, which
+	 * only receives the device code.
+	 */
+	constructor(
+		private readonly pollIntervalMs = DEFAULT_POLL_INTERVAL_SECONDS * 1000,
+	) {}
+
+	getOAuthConfig(): OAuthProviderConfig {
+		return {
+			authorizeUrl: KIMI_OAUTH_DEVICE_AUTHORIZATION_URL,
+			tokenUrl: KIMI_OAUTH_TOKEN_URL,
+			clientId: KIMI_OAUTH_CLIENT_ID,
+			scopes: [],
+			// Device flow never redirects anywhere.
+			redirectUri: "",
+		};
+	}
+
+	generateAuthUrl(): string {
+		throw new OAuthError(
+			"Kimi uses the OAuth device authorization grant; call beginDeviceAuthorization instead.",
+			"kimi",
+		);
+	}
+
+	async beginDeviceAuthorization(
+		config: OAuthProviderConfig,
+	): Promise<DeviceAuthorization> {
+		const { status, json } = await postForm(config.authorizeUrl, {
+			client_id: config.clientId,
+		});
+
+		if (status !== 200) {
+			const error = json as TokenResponse;
+			throw new OAuthError(
+				error.error_description ||
+					error.error ||
+					`Device authorization failed (HTTP ${status})`,
+				"kimi",
+				error.error,
+			);
+		}
+
+		const data = json as DeviceAuthorizationResponse;
+		if (!data.device_code || !data.user_code) {
+			throw new OAuthError(
+				"Device authorization response missing device_code or user_code",
+				"kimi",
+			);
+		}
+
+		const verificationUri = data.verification_uri ?? "";
+		return {
+			deviceCode: data.device_code,
+			userCode: data.user_code,
+			verificationUri,
+			verificationUriComplete:
+				data.verification_uri_complete ?? verificationUri,
+			interval: data.interval ?? DEFAULT_POLL_INTERVAL_SECONDS,
+			expiresAt: Date.now() + (data.expires_in ?? 1800) * 1000,
+		};
+	}
+
+	/**
+	 * Polls the token endpoint with the device code. `code` is unused: the
+	 * device grant has no user-supplied authorization code, and the device code
+	 * arrives via `verifier` (where the OAuth flow persists it).
+	 */
+	async exchangeCode(
+		_code: string,
+		verifier: string,
+		config: OAuthProviderConfig,
+	): Promise<TokenResult> {
+		if (!verifier) {
+			throw new OAuthError("Missing device code for Kimi OAuth flow", "kimi");
+		}
+
+		const deadline = Date.now() + MAX_POLL_DURATION_MS;
+		let intervalMs = this.pollIntervalMs;
+
+		while (Date.now() < deadline) {
+			const { status, json } = await postForm(config.tokenUrl, {
+				client_id: config.clientId,
+				device_code: verifier,
+				grant_type: KIMI_DEVICE_GRANT_TYPE,
+			});
+			const data = json as TokenResponse;
+
+			if (status === 200 && data.access_token) {
+				return {
+					accessToken: data.access_token,
+					refreshToken: data.refresh_token ?? "",
+					expiresAt:
+						data.expires_at ?? Date.now() + (data.expires_in ?? 900) * 1000,
+				};
+			}
+
+			if (status >= 500) {
+				throw new OAuthError(
+					`Kimi token polling server error (HTTP ${status})`,
+					"kimi",
+				);
+			}
+
+			switch (data.error) {
+				case "authorization_pending":
+					break;
+				case "slow_down":
+					intervalMs += 5000;
+					break;
+				case "expired_token":
+					throw new OAuthError(
+						"Device authorization expired before it was approved. Please try again.",
+						"kimi",
+						data.error,
+					);
+				case "access_denied":
+					throw new OAuthError(
+						"Device authorization was denied.",
+						"kimi",
+						data.error,
+					);
+				default:
+					throw new OAuthError(
+						data.error_description ||
+							data.error ||
+							`Kimi token polling failed (HTTP ${status})`,
+						"kimi",
+						data.error,
+					);
+			}
+
+			await sleep(intervalMs);
+		}
+
+		throw new OAuthError(
+			"Timed out waiting for Kimi device authorization to be approved.",
+			"kimi",
+		);
+	}
+}

--- a/packages/providers/src/providers/kimi/provider.test.ts
+++ b/packages/providers/src/providers/kimi/provider.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Account } from "@ccflare/types";
+import { KIMI_OAUTH_CLIENT_ID, KIMI_OAUTH_TOKEN_URL } from "./oauth";
+import { KimiProvider } from "./provider";
+
+const originalFetch = globalThis.fetch;
+
+function account(overrides: Partial<Account> = {}): Account {
+	return {
+		id: "kimi-account",
+		name: "kimi",
+		provider: "kimi",
+		api_key: null,
+		refresh_token: "stored-refresh",
+		access_token: "stored-access",
+		expires_at: Date.now() + 900_000,
+		request_count: 0,
+		total_requests: 0,
+		last_used: null,
+		created_at: Date.now(),
+		rate_limited_until: null,
+		session_start: null,
+		session_request_count: 0,
+		account_tier: 1,
+		paused: false,
+		rate_limit_reset: null,
+		rate_limit_status: null,
+		rate_limit_remaining: null,
+		auth_method: "oauth",
+		base_url: null,
+		...overrides,
+	} as Account;
+}
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("KimiProvider", () => {
+	it("builds upstream URLs from the stripped Kimi path", () => {
+		const provider = new KimiProvider();
+		expect(provider.buildUrl("/chat/completions", "")).toBe(
+			"https://api.kimi.com/coding/v1/chat/completions",
+		);
+	});
+
+	it("sets Bearer auth and strips Anthropic-family headers", () => {
+		const provider = new KimiProvider();
+		const headers = provider.prepareHeaders(
+			new Headers({
+				"x-api-key": "leftover",
+				"anthropic-version": "2023-06-01",
+				host: "localhost:8080",
+			}),
+			account(),
+		);
+
+		expect(headers.get("Authorization")).toBe("Bearer stored-access");
+		expect(headers.get("x-api-key")).toBeNull();
+		expect(headers.get("anthropic-version")).toBeNull();
+		expect(headers.get("host")).toBeNull();
+	});
+
+	it("refreshes with the device-flow client id and honors token rotation", async () => {
+		const provider = new KimiProvider();
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL, init?: RequestInit) => {
+				const request = new Request(input, init);
+				expect(request.url).toBe(KIMI_OAUTH_TOKEN_URL);
+				const body = await request.text();
+				expect(body).toContain("grant_type=refresh_token");
+				expect(body).toContain("refresh_token=stored-refresh");
+				expect(body).toContain(`client_id=${KIMI_OAUTH_CLIENT_ID}`);
+
+				return new Response(
+					JSON.stringify({
+						access_token: "new-access",
+						refresh_token: "rotated-refresh",
+						expires_in: 900,
+					}),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				);
+			},
+			{ preconnect: originalFetch.preconnect },
+		) as typeof fetch;
+
+		const result = await provider.refreshToken(account(), "ignored-client-id");
+
+		expect(result.accessToken).toBe("new-access");
+		expect(result.refreshToken).toBe("rotated-refresh");
+		expect(result.expiresAt).toBeGreaterThan(Date.now());
+	});
+
+	it("keeps the stored refresh token when the server omits a new one", async () => {
+		const provider = new KimiProvider();
+		globalThis.fetch = Object.assign(
+			async () =>
+				new Response(
+					JSON.stringify({ access_token: "new-access", expires_in: 900 }),
+					{ status: 200, headers: { "content-type": "application/json" } },
+				),
+			{ preconnect: originalFetch.preconnect },
+		) as typeof fetch;
+
+		const result = await provider.refreshToken(account(), "ignored-client-id");
+
+		expect(result.refreshToken).toBe("stored-refresh");
+	});
+});

--- a/packages/providers/src/providers/kimi/provider.ts
+++ b/packages/providers/src/providers/kimi/provider.ts
@@ -1,0 +1,89 @@
+import { Logger } from "@ccflare/logger";
+import { type Account, getProviderDefaultBaseUrl } from "@ccflare/types";
+import { deleteTransportHeaders } from "../../base";
+import {
+	executeTokenRefresh,
+	type RefreshRequestConfig,
+} from "../../token-refresh";
+import type { TokenRefreshResult } from "../../types";
+import { OpenAIProvider } from "../openai/provider";
+import {
+	KIMI_OAUTH_CLIENT_ID,
+	KIMI_OAUTH_TOKEN_URL,
+	KimiOAuthProvider,
+} from "./oauth";
+
+const log = new Logger("KimiProvider");
+const PROVIDER_NAME = "kimi" as const;
+const DEFAULT_BASE_URL = getProviderDefaultBaseUrl(PROVIDER_NAME);
+
+/**
+ * Kimi access tokens are short-lived (900s), so the proxy refreshes far more
+ * often than for other providers. The refresh token is rotated on every
+ * successful refresh; fall back to the stored one only if the server omits it.
+ */
+const KIMI_REFRESH_CONFIG: RefreshRequestConfig = {
+	tokenUrl: KIMI_OAUTH_TOKEN_URL,
+	contentType: "application/x-www-form-urlencoded",
+	buildBody(refreshToken: string, _clientId: string) {
+		return new URLSearchParams({
+			grant_type: "refresh_token",
+			refresh_token: refreshToken,
+			client_id: KIMI_OAUTH_CLIENT_ID,
+		}).toString();
+	},
+	parseTokens(json: Record<string, unknown>, account: Account) {
+		const expiresAt =
+			(json.expires_at as number | undefined) ??
+			Date.now() + ((json.expires_in as number | undefined) ?? 900) * 1000;
+		return {
+			accessToken: json.access_token as string,
+			expiresAt,
+			refreshToken:
+				(json.refresh_token as string | undefined) ??
+				account.refresh_token ??
+				"",
+		};
+	},
+};
+
+/**
+ * Kimi Code exposes an OpenAI-compatible chat-completions API at
+ * `https://api.kimi.com/coding/v1`, so URL building, rate-limit parsing and
+ * usage extraction are inherited from the OpenAI provider. Only auth differs.
+ */
+export class KimiProvider extends OpenAIProvider {
+	name: string = PROVIDER_NAME;
+	defaultBaseUrl: string = DEFAULT_BASE_URL;
+
+	async refreshToken(
+		account: Account,
+		clientId: string,
+	): Promise<TokenRefreshResult> {
+		return executeTokenRefresh(account, clientId, KIMI_REFRESH_CONFIG, log);
+	}
+
+	prepareHeaders(headers: Headers, account: Account | null): Headers {
+		const newHeaders = new Headers(headers);
+
+		if (account?.access_token) {
+			newHeaders.set("Authorization", `Bearer ${account.access_token}`);
+		}
+
+		// Remove Anthropic-family headers that don't belong on Kimi requests.
+		newHeaders.delete("x-api-key");
+		newHeaders.delete("anthropic-version");
+
+		deleteTransportHeaders(newHeaders);
+
+		return newHeaders;
+	}
+
+	supportsOAuth(): boolean {
+		return true;
+	}
+
+	getOAuthProvider() {
+		return new KimiOAuthProvider();
+	}
+}

--- a/packages/providers/src/types.ts
+++ b/packages/providers/src/types.ts
@@ -83,6 +83,22 @@ export interface OAuthProviderConfig {
 	redirectUri: string;
 }
 
+/**
+ * Result of an OAuth device authorization request (RFC 8628).
+ * `deviceCode` is the polling credential; the user approves at
+ * `verificationUriComplete`.
+ */
+export interface DeviceAuthorization {
+	deviceCode: string;
+	userCode: string;
+	verificationUri: string;
+	verificationUriComplete: string;
+	/** Seconds to wait between token polls. */
+	interval: number;
+	/** Epoch ms after which the device code is no longer valid. */
+	expiresAt: number;
+}
+
 export interface OAuthProvider {
 	getOAuthConfig(): OAuthProviderConfig;
 	exchangeCode(
@@ -91,6 +107,14 @@ export interface OAuthProvider {
 		config: OAuthProviderConfig,
 	): Promise<TokenResult>;
 	generateAuthUrl(config: OAuthProviderConfig, pkce: PKCEChallenge): string;
+	/**
+	 * Device-code providers implement this instead of the PKCE redirect flow.
+	 * When present, the OAuth flow starts here and `exchangeCode` receives the
+	 * device code in its `verifier` argument, ignoring `code`.
+	 */
+	beginDeviceAuthorization?(
+		config: OAuthProviderConfig,
+	): Promise<DeviceAuthorization>;
 }
 
 export interface PKCEChallenge {

--- a/packages/proxy/src/post-processor.worker.ts
+++ b/packages/proxy/src/post-processor.worker.ts
@@ -685,12 +685,16 @@ async function handleEnd(msg: EndMessage): Promise<void> {
 		state.usage.costUsd =
 			usageModel === "unknown"
 				? 0
-				: await estimateCostUSD(usageModel, {
-						inputTokens: state.usage.inputTokens,
-						outputTokens: finalOutputTokens,
-						cacheReadInputTokens: state.usage.cacheReadInputTokens,
-						cacheCreationInputTokens: state.usage.cacheCreationInputTokens,
-					});
+				: await estimateCostUSD(
+						usageModel,
+						{
+							inputTokens: state.usage.inputTokens,
+							outputTokens: finalOutputTokens,
+							cacheReadInputTokens: state.usage.cacheReadInputTokens,
+							cacheCreationInputTokens: state.usage.cacheCreationInputTokens,
+						},
+						{ provider: startMessage.providerName },
+					);
 
 		// Calculate tokens per second using actual streaming duration
 		if (finalOutputTokens > 0) {

--- a/packages/types/src/account.test.ts
+++ b/packages/types/src/account.test.ts
@@ -13,6 +13,7 @@ describe("toAccount", () => {
 			"openai",
 			"claude-code",
 			"codex",
+			"kimi",
 		]);
 	});
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,7 @@ export * from "./conversation";
 export * from "./conversation-links";
 export * from "./guards";
 export * from "./logging";
+export * from "./pricing-catalogue";
 export * from "./provider-metadata";
 export * from "./request";
 export * from "./request-events";

--- a/packages/types/src/pricing-catalogue.ts
+++ b/packages/types/src/pricing-catalogue.ts
@@ -1,0 +1,91 @@
+import type { AccountProvider } from "./provider-metadata";
+
+/**
+ * How one ccflare provider's model ids map onto the models.dev catalogue.
+ *
+ * Pricing itself is never stored here. ccflare has a single price source --
+ * the models.dev catalogue fetched by `@ccflare/core`'s pricing module -- and
+ * this file only says *where in that catalogue to look*. Rates therefore stay
+ * current without anyone editing this repo.
+ *
+ * Two facts need expressing:
+ *
+ * 1. `catalogues` -- which catalogue provider blocks to consult first. The
+ *    catalogue is keyed by provider, and the same model id appears under many
+ *    resellers at different rates, so an unordered scan would price a request
+ *    at whichever block happened to come first in the JSON. Naming the
+ *    first-party block makes the lookup deterministic.
+ * 2. `modelAliases` -- the catalogue id for a model whose ccflare-visible id
+ *    differs. Subscription plans are the reason this exists: they publish
+ *    plan-specific ids that the catalogue lists at zero cost because the plan
+ *    is flat-rate. Aliasing them onto the metered id records what the traffic
+ *    would have cost at list price, which is what makes providers comparable
+ *    in the dashboard.
+ */
+export interface ProviderPricingSource {
+	/** Catalogue provider blocks to consult, in order, before a full scan. */
+	readonly catalogues: readonly string[];
+	/** ccflare model id -> models.dev model id, for ids that differ. */
+	readonly modelAliases?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Kimi Code is a flat-rate subscription. models.dev carries its plan ids under
+ * a `kimi-for-coding` block priced at zero, so without these aliases every Kimi
+ * request records $0 and cannot be compared against any other provider.
+ *
+ * The targets are Moonshot's own metered ids. `k3-256k` is the same model as
+ * `k3` behind a smaller context limit and Moonshot does not price it
+ * separately, so both alias to `kimi-k3`.
+ */
+const KIMI_MODEL_ALIASES: Record<string, string> = {
+	"kimi-for-coding": "kimi-k2.7-code",
+	"kimi-for-coding-highspeed": "kimi-k2.7-code-highspeed",
+	k3: "kimi-k3",
+	"k3-256k": "kimi-k3",
+};
+
+const PROVIDER_PRICING_SOURCES: Readonly<
+	Record<AccountProvider, ProviderPricingSource>
+> = {
+	anthropic: { catalogues: ["anthropic"] },
+	openai: { catalogues: ["openai"] },
+	"claude-code": { catalogues: ["anthropic"] },
+	codex: { catalogues: ["openai"] },
+	kimi: { catalogues: ["moonshotai"], modelAliases: KIMI_MODEL_ALIASES },
+};
+
+/** Where to price one model id, given the account provider that served it. */
+export interface PricingCatalogueLookup {
+	/** Model id to look up in the catalogue. */
+	readonly modelId: string;
+	/** Catalogue provider blocks to try first, in order. */
+	readonly catalogues: readonly string[];
+}
+
+function isKnownProvider(
+	provider: string | undefined,
+): provider is AccountProvider {
+	return provider !== undefined && provider in PROVIDER_PRICING_SOURCES;
+}
+
+/**
+ * Resolve a request's model id to its catalogue coordinates.
+ *
+ * An unknown or absent provider is not an error: the caller then does a plain
+ * catalogue-wide lookup on the id as sent, which is the pre-existing behavior.
+ */
+export function resolvePricingCatalogueLookup(
+	modelId: string,
+	provider?: string,
+): PricingCatalogueLookup {
+	if (!isKnownProvider(provider)) {
+		return { modelId, catalogues: [] };
+	}
+
+	const source = PROVIDER_PRICING_SOURCES[provider];
+	return {
+		modelId: source.modelAliases?.[modelId] ?? modelId,
+		catalogues: source.catalogues,
+	};
+}

--- a/packages/types/src/provider-metadata.test.ts
+++ b/packages/types/src/provider-metadata.test.ts
@@ -5,7 +5,9 @@ import {
 	API_KEY_PROVIDERS,
 	getProviderDisplayLabel,
 	getProviderMetadata,
+	getProviderOAuthGrant,
 	isApiKeyProvider,
+	isDeviceCodeProvider,
 	isOAuthProvider,
 	OAUTH_PROVIDERS,
 } from "./provider-metadata";
@@ -17,9 +19,10 @@ describe("provider metadata", () => {
 			"openai",
 			"claude-code",
 			"codex",
+			"kimi",
 		]);
 		expect(API_KEY_PROVIDERS).toEqual(["anthropic", "openai"]);
-		expect(OAUTH_PROVIDERS).toEqual(["claude-code", "codex"]);
+		expect(OAUTH_PROVIDERS).toEqual(["claude-code", "codex", "kimi"]);
 		expect(isApiKeyProvider("anthropic")).toBe(true);
 		expect(isApiKeyProvider("claude-code")).toBe(false);
 		expect(isOAuthProvider("codex")).toBe(true);
@@ -32,6 +35,7 @@ describe("provider metadata", () => {
 			{ value: "openai", label: "OpenAI" },
 			{ value: "claude-code", label: "Claude Code" },
 			{ value: "codex", label: "Codex" },
+			{ value: "kimi", label: "Kimi Code" },
 		]);
 		expect(getProviderDisplayLabel("claude-code")).toBe("Claude Code");
 		expect(getProviderMetadata("anthropic")).toMatchObject({
@@ -51,6 +55,22 @@ describe("provider metadata", () => {
 			supportsWebSocket: true,
 			defaultBaseUrl: "https://chatgpt.com/backend-api/codex",
 			specialRequirements: ["Requires Codex OAuth authentication"],
+		});
+	});
+
+	it("distinguishes device-code onboarding from authorization-code onboarding", () => {
+		expect(getProviderOAuthGrant("kimi")).toBe("device_code");
+		expect(getProviderOAuthGrant("codex")).toBe("authorization_code");
+		expect(getProviderOAuthGrant("openai")).toBe("none");
+		expect(isDeviceCodeProvider("kimi")).toBe(true);
+		expect(isDeviceCodeProvider("codex")).toBe(false);
+		expect(getProviderMetadata("kimi")).toMatchObject({
+			canonicalName: "kimi",
+			displayLabel: "Kimi Code",
+			authMethod: "oauth",
+			supportsOAuth: true,
+			supportsWebSocket: false,
+			defaultBaseUrl: "https://api.kimi.com/coding/v1",
 		});
 	});
 });

--- a/packages/types/src/provider-metadata.ts
+++ b/packages/types/src/provider-metadata.ts
@@ -3,6 +3,7 @@ const PROVIDER_METADATA_MAP = {
 		displayLabel: "Anthropic",
 		authMethod: "api_key",
 		supportsOAuth: false,
+		oauthGrant: "none",
 		supportsWebSocket: false,
 		defaultBaseUrl: "https://api.anthropic.com",
 		specialRequirements: [],
@@ -11,6 +12,7 @@ const PROVIDER_METADATA_MAP = {
 		displayLabel: "OpenAI",
 		authMethod: "api_key",
 		supportsOAuth: false,
+		oauthGrant: "none",
 		supportsWebSocket: false,
 		defaultBaseUrl: "https://api.openai.com/v1",
 		specialRequirements: [],
@@ -19,6 +21,7 @@ const PROVIDER_METADATA_MAP = {
 		displayLabel: "Claude Code",
 		authMethod: "oauth",
 		supportsOAuth: true,
+		oauthGrant: "authorization_code",
 		supportsWebSocket: false,
 		defaultBaseUrl: "https://api.anthropic.com",
 		specialRequirements: ["Requires Claude Code OAuth authentication"],
@@ -27,9 +30,21 @@ const PROVIDER_METADATA_MAP = {
 		displayLabel: "Codex",
 		authMethod: "oauth",
 		supportsOAuth: true,
+		oauthGrant: "authorization_code",
 		supportsWebSocket: true,
 		defaultBaseUrl: "https://chatgpt.com/backend-api/codex",
 		specialRequirements: ["Requires Codex OAuth authentication"],
+	},
+	kimi: {
+		displayLabel: "Kimi Code",
+		authMethod: "oauth",
+		supportsOAuth: true,
+		oauthGrant: "device_code",
+		supportsWebSocket: false,
+		defaultBaseUrl: "https://api.kimi.com/coding/v1",
+		specialRequirements: [
+			"Requires Kimi Code OAuth device authorization (approve in browser, no code to paste)",
+		],
 	},
 } as const satisfies Record<
 	string,
@@ -37,11 +52,21 @@ const PROVIDER_METADATA_MAP = {
 		displayLabel: string;
 		authMethod: "api_key" | "oauth";
 		supportsOAuth: boolean;
+		oauthGrant: OAuthGrant;
 		supportsWebSocket: boolean;
 		defaultBaseUrl: string;
 		specialRequirements: readonly string[];
 	}
 >;
+
+/**
+ * Which OAuth grant a provider's onboarding uses.
+ *
+ * `authorization_code` hands the user a redirect URL and expects an
+ * authorization code back. `device_code` hands the user a verification URL and
+ * polls the token endpoint instead -- there is no code for the user to paste.
+ */
+export type OAuthGrant = "none" | "authorization_code" | "device_code";
 
 type ProviderMetadataMap = typeof PROVIDER_METADATA_MAP;
 
@@ -121,6 +146,21 @@ export function isOAuthProvider(value: string): value is OAuthProvider {
 		isAccountProvider(value) &&
 		PROVIDER_METADATA_MAP[value].authMethod === "oauth"
 	);
+}
+
+/**
+ * True when onboarding this provider uses the OAuth device authorization
+ * grant, i.e. the user approves in a browser and no code comes back.
+ */
+export function isDeviceCodeProvider(value: string): value is OAuthProvider {
+	return (
+		isAccountProvider(value) &&
+		PROVIDER_METADATA_MAP[value].oauthGrant === "device_code"
+	);
+}
+
+export function getProviderOAuthGrant(provider: AccountProvider): OAuthGrant {
+	return PROVIDER_METADATA_MAP[provider].oauthGrant;
 }
 
 export function getProviderMetadata<P extends AccountProvider>(


### PR DESCRIPTION
Kimi added support for kimi-code via oauth, if you want to merge.

**Commit-message**
Adds `kimi` as a native passthrough provider and gives its traffic a meaningful cost in the dashboard.

Provider:

- OAuth device authorization grant (RFC 8628), a first for this repo, so the shared OAuth flow, the API handler, the TUI and the dashboard form now branch on `beginDeviceAuthorization` instead of assuming a PKCE redirect with a pasted code.
- `KimiProvider` extends `OpenAIProvider`: the upstream at `https://api.kimi.com/coding/v1` is OpenAI-compatible chat-completions, so only auth differs. Access tokens live 900s and the refresh token rotates on every refresh.
- Requests route through `/v1/kimi/*`.

Costing:

ccflare's only price source is the models.dev catalogue, and that catalogue lists Kimi's plan model ids under a `kimi-for-coding` block at zero cost because the plan is flat-rate. Every Kimi request was therefore recorded at $0 and could not be compared against Claude Code or Codex, which pick up real Anthropic and OpenAI list prices from the same catalogue.

`packages/types/src/pricing-catalogue.ts` now maps each provider to the catalogue blocks to read and, where the ids differ, their metered equivalents (`kimi-for-coding` -> `kimi-k2.7-code`, `k3` and `k3-256k` -> `kimi-k3`, and so on). No rates are hardcoded; only where to look, so prices stay live.

Naming the catalogue block also fixes an existing ambiguity that affected every provider: the lookup scanned all blocks and took the first id match in JSON key order, so `gpt-5.3-codex` could be priced off a reseller's markup rather than OpenAI's own entry. First-party blocks are now consulted first, with the old catalogue-wide scan kept as a fallback for callers with no provider hint.

Costs remain list-price equivalents rather than billed amounts, which is already how subscription accounts were treated. `docs/providers.md` gains a "Request Cost" section saying so.

Quota fetching is still unimplemented for Kimi.