### PR TITLE
Load request payloads lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ Key endpoints:
 - `POST /api/accounts/:id/pause` / `resume` — exclude or restore an account
 - `POST /api/accounts/:id/rename` — rename an account
 - `GET /api/requests` — recent request summaries
-- `GET /api/requests/detail` — detailed request info with payloads
-- `GET /api/requests/stream` — live request stream via SSE
+- `GET /api/requests/:id/detail` — detailed request payload for one exact request ID
+- `GET /api/requests/stream` — live request summary stream via SSE
 - `GET /api/analytics` — aggregated analytics
 - `GET /api/stats` — usage and performance stats
 - `POST /api/stats/reset` — reset usage statistics

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { api } from "./api";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("request detail client", () => {
+	it("fetches one exact encoded request id", async () => {
+		const urls: string[] = [];
+		globalThis.fetch = Object.assign(
+			async (input: RequestInfo | URL) => {
+				urls.push(String(input));
+				return new Response(
+					JSON.stringify({
+						id: "id/with space",
+						request: { headers: {}, body: null },
+						response: null,
+						meta: {
+							trace: { timestamp: 1 },
+							account: { id: null },
+							transport: { pending: true },
+						},
+					}),
+					{ headers: { "content-type": "application/json" } },
+				);
+			},
+			{ preconnect: originalFetch.preconnect },
+		) as typeof fetch;
+
+		const detail = await api.getRequestDetail("id/with space");
+
+		expect(detail.id).toBe("id/with space");
+		expect(urls).toEqual(["/api/requests/id%2Fwith%20space/detail"]);
+	});
+});

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -164,11 +164,9 @@ class API extends HttpClient {
 		return eventSource;
 	}
 
-	async getRequestsDetail(
-		limit: number = API_LIMITS.requestsDetail,
-	): Promise<RequestPayload[]> {
-		return this.getJson<RequestPayload[]>(
-			`/api/requests/detail?limit=${limit}`,
+	async getRequestDetail(requestId: string): Promise<RequestPayload> {
+		return this.getJson<RequestPayload>(
+			`/api/requests/${encodeURIComponent(requestId)}/detail`,
 		);
 	}
 

--- a/apps/web/src/components/CopyButton.test.ts
+++ b/apps/web/src/components/CopyButton.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { resolveCopyValue } from "./CopyButton";
+
+describe("resolveCopyValue", () => {
+	it("supports async producers and suppresses duplicate resolutions", async () => {
+		const lock = { current: false };
+		let release: ((value: string) => void) | undefined;
+		const produced = new Promise<string>((resolve) => {
+			release = resolve;
+		});
+		const writes: string[] = [];
+		const first = resolveCopyValue(
+			lock,
+			() => produced,
+			async (text) => {
+				writes.push(text);
+			},
+		);
+		const duplicate = await resolveCopyValue(
+			lock,
+			() => "duplicate",
+			async (text) => {
+				writes.push(text);
+			},
+		);
+
+		expect(duplicate).toBe(false);
+		release?.("resolved");
+		expect(await first).toBe(true);
+		expect(writes).toEqual(["resolved"]);
+	});
+
+	it("releases the lock after producer errors", async () => {
+		const lock = { current: false };
+		await expect(
+			resolveCopyValue(
+				lock,
+				async () => {
+					throw new Error("detail failed");
+				},
+				async () => {},
+			),
+		).rejects.toThrow("detail failed");
+		expect(lock.current).toBe(false);
+	});
+});

--- a/apps/web/src/components/CopyButton.tsx
+++ b/apps/web/src/components/CopyButton.tsx
@@ -8,7 +8,7 @@ interface CopyButtonProps {
 	 * String or function returning the string to copy.
 	 */
 	value?: string;
-	getValue?: () => string;
+	getValue?: () => string | Promise<string>;
 	/**
 	 * Forwarded props to underlying Button
 	 */
@@ -25,6 +25,23 @@ interface CopyButtonProps {
 	title?: string;
 }
 
+export async function resolveCopyValue(
+	lock: { current: boolean },
+	producer: () => string | Promise<string>,
+	writeText: (text: string) => Promise<void>,
+): Promise<boolean> {
+	if (lock.current) return false;
+	lock.current = true;
+	try {
+		const text = await producer();
+		if (!text) return false;
+		await writeText(text);
+		return true;
+	} finally {
+		lock.current = false;
+	}
+}
+
 /**
  * A small wrapper around the standard Button that copies supplied text to the
  * clipboard and temporarily shows a "Copied!" label with a subtle animation.
@@ -39,23 +56,32 @@ export function CopyButton({
 	title,
 }: CopyButtonProps) {
 	const [copied, setCopied] = useState(false);
+	const [resolving, setResolving] = useState(false);
+	const resolvingRef = useRef(false);
 	const timeoutRef = useRef<number | null>(null);
 
-	const handleCopy = () => {
-		const text = typeof getValue === "function" ? getValue() : (value ?? "");
-		if (!text) return;
-
-		navigator.clipboard
-			.writeText(text)
-			.then(() => {
+	const handleCopy = async () => {
+		if (resolvingRef.current) return;
+		setResolving(true);
+		try {
+			const didCopy = await resolveCopyValue(
+				resolvingRef,
+				typeof getValue === "function" ? getValue : () => value ?? "",
+				(text) => navigator.clipboard.writeText(text),
+			);
+			if (didCopy) {
 				setCopied(true);
 				// Reset after 1.5s
 				if (timeoutRef.current) {
 					window.clearTimeout(timeoutRef.current);
 				}
 				timeoutRef.current = window.setTimeout(() => setCopied(false), 1500);
-			})
-			.catch((err) => console.error("Failed to copy", err));
+			}
+		} catch (err) {
+			console.error("Failed to copy", err);
+		} finally {
+			setResolving(false);
+		}
 	};
 
 	return (
@@ -63,6 +89,7 @@ export function CopyButton({
 			variant={variant}
 			size={size}
 			onClick={handleCopy}
+			disabled={resolving}
 			title={title}
 			className={cn("relative overflow-hidden", className)}
 		>

--- a/apps/web/src/components/RequestDetailsModal.tsx
+++ b/apps/web/src/components/RequestDetailsModal.tsx
@@ -15,6 +15,7 @@ import { Eye } from "lucide-react";
 import { useMemo, useState } from "react";
 import { api } from "../api";
 import { queryKeys } from "../lib/query-keys";
+import type { RequestListItem } from "../lib/request-list-model";
 import { getStatusCodeBadgeVariant } from "../lib/request-status";
 import { ConversationView } from "./ConversationView";
 import { CopyButton } from "./CopyButton";
@@ -32,26 +33,34 @@ import { Switch } from "./ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 
 interface RequestDetailsModalProps {
-	request: RequestPayload;
-	summary: RequestSummary | undefined;
+	item: RequestListItem;
 	isOpen: boolean;
 	onClose: () => void;
 }
 
 export function RequestDetailsModal({
-	request,
-	summary,
+	item,
 	isOpen,
 	onClose,
 }: RequestDetailsModalProps) {
 	const [beautifyMode, setBeautifyMode] = useState(true);
+	const summary: RequestSummary | undefined = item.summary ?? undefined;
+	const {
+		data: request,
+		isLoading: detailLoading,
+		error: detailError,
+	} = useQuery<RequestPayload>({
+		queryKey: queryKeys.requestDetail(item.id),
+		queryFn: () => api.getRequestDetail(item.id),
+		enabled: isOpen,
+	});
 	const {
 		data: conversationChain = [],
 		isLoading: conversationLoading,
 		error: conversationError,
 	} = useQuery({
-		queryKey: queryKeys.requestConversation(request.id),
-		queryFn: () => api.getRequestConversation(request.id),
+		queryKey: queryKeys.requestConversation(item.id),
+		queryFn: () => api.getRequestConversation(item.id),
 		enabled: isOpen,
 	});
 	const conversationEntries = useMemo(
@@ -71,7 +80,40 @@ export function RequestDetailsModal({
 	const formatBody = (body: string | null) =>
 		formatBodyBase(body, beautifyMode);
 
-	const statusCode = request.response?.status;
+	const statusCode = item.statusCode;
+
+	if (!request) {
+		return (
+			<Dialog open={isOpen} onOpenChange={onClose}>
+				<DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+					<DialogHeader>
+						<DialogTitle className="flex items-center gap-2">
+							<Eye className="h-5 w-5" />
+							Request Details
+						</DialogTitle>
+						<DialogDescription className="flex items-center gap-2 flex-wrap">
+							<span className="font-mono text-sm">
+								{formatTimestamp(item.timestamp)}
+							</span>
+							<span className="font-medium">{item.method}</span>
+							<span className="font-mono">{item.path}</span>
+						</DialogDescription>
+					</DialogHeader>
+					<div
+						className={`flex items-center justify-center h-32 ${
+							detailError ? "text-destructive" : "text-muted-foreground"
+						}`}
+					>
+						{detailLoading
+							? "Loading request details..."
+							: detailError instanceof Error
+								? detailError.message
+								: "Failed to load request details"}
+					</div>
+				</DialogContent>
+			</Dialog>
+		);
+	}
 
 	return (
 		<Dialog open={isOpen} onOpenChange={onClose}>
@@ -84,7 +126,7 @@ export function RequestDetailsModal({
 					<DialogDescription className="flex items-center justify-between">
 						<div className="flex items-center gap-2 flex-wrap">
 							<span className="font-mono text-sm">
-								{formatTimestamp(request.meta.trace.timestamp)}
+								{formatTimestamp(item.timestamp)}
 							</span>
 							{statusCode && (
 								<Badge variant={getStatusCodeBadgeVariant(statusCode)}>

--- a/apps/web/src/components/RequestsTab.tsx
+++ b/apps/web/src/components/RequestsTab.tsx
@@ -19,7 +19,9 @@ import {
 	X,
 } from "lucide-react";
 import { useState } from "react";
+import { api } from "../api";
 import { useRequestsPageModel } from "../hooks/useRequestsPageModel";
+import type { RequestListItem } from "../lib/request-list-model";
 import { getStatusCodeTextClass } from "../lib/request-status";
 import { CopyButton } from "./CopyButton";
 import { RequestDetailsModal } from "./RequestDetailsModal";
@@ -52,12 +54,11 @@ export function RequestsTab() {
 	const [expandedRequests, setExpandedRequests] = useState<Set<string>>(
 		new Set(),
 	);
-	const [modalRequest, setModalRequest] = useState<RequestPayload | null>(null);
+	const [modalItem, setModalItem] = useState<RequestListItem | null>(null);
 	const [showFilters, setShowFilters] = useState(false);
 
 	const {
 		requests,
-		summaries,
 		allRequests,
 		accountFilter,
 		setAccountFilter,
@@ -422,9 +423,12 @@ export function RequestsTab() {
 					<div className="space-y-2">
 						{requests.map((request) => {
 							const isExpanded = expandedRequests.has(request.id);
-							const isError = request.error || !request.meta.transport.success;
-							const statusCode = request.response?.status;
-							const summary = summaries.get(request.id);
+							const isError =
+								!request.pending &&
+								(Boolean(request.summary?.errorMessage) ||
+									request.summary?.success === false);
+							const statusCode = request.statusCode;
+							const summary = request.summary ?? undefined;
 
 							return (
 								<div
@@ -432,9 +436,7 @@ export function RequestsTab() {
 									className={`border rounded-lg p-3 transition-all duration-300 ${
 										isError ? "border-destructive/50" : "border-border"
 									} ${
-										request.meta.transport.pending
-											? "animate-pulse opacity-70"
-											: "opacity-100"
+										request.pending ? "animate-pulse opacity-70" : "opacity-100"
 									}`}
 								>
 									<button
@@ -449,18 +451,16 @@ export function RequestsTab() {
 												<ChevronRight className="h-4 w-4" />
 											)}
 											<span className="text-sm font-mono">
-												{new Date(
-													request.meta.trace.timestamp,
-												).toLocaleTimeString()}
+												{new Date(request.timestamp).toLocaleTimeString()}
 											</span>
-											{(request.meta.trace.method || summary?.method) && (
+											{request.method && (
 												<span className="text-sm font-medium">
-													{request.meta.trace.method || summary?.method}
+													{request.method}
 												</span>
 											)}
-											{(request.meta.trace.path || summary?.path) && (
+											{request.path && (
 												<span className="text-sm text-muted-foreground font-mono">
-													{request.meta.trace.path || summary?.path}
+													{request.path}
 												</span>
 											)}
 											{statusCode && (
@@ -477,8 +477,7 @@ export function RequestsTab() {
 													{summary.model}
 												</Badge>
 											)}
-											{(summary?.totalTokens ||
-												request.meta.transport.pending) && (
+											{(summary?.totalTokens || request.pending) && (
 												<Badge variant="outline" className="text-xs">
 													{summary?.totalTokens
 														? formatTokens(summary.totalTokens)
@@ -486,7 +485,7 @@ export function RequestsTab() {
 													tokens
 												</Badge>
 											)}
-											{(summary?.costUsd || request.meta.transport.pending) && (
+											{(summary?.costUsd || request.pending) && (
 												<Badge variant="default" className="text-xs">
 													{summary?.costUsd && summary.costUsd > 0
 														? formatCost(summary.costUsd)
@@ -499,37 +498,35 @@ export function RequestsTab() {
 														{formatTokensPerSecond(summary.tokensPerSecond)}
 													</Badge>
 												)}
-											{(request.meta.account.name ||
-												request.meta.account.id) && (
+											{(request.accountName || request.accountId) && (
 												<span className="text-sm text-muted-foreground">
 													via{" "}
-													{request.meta.account.name ||
-														`${request.meta.account.id?.slice(0, 8)}...`}
+													{request.accountName ||
+														`${request.accountId?.slice(0, 8)}...`}
 												</span>
 											)}
-											{request.meta.transport.rateLimited && (
+											{statusCode === 429 && (
 												<Badge variant="warning" className="text-xs">
 													Rate Limited
 												</Badge>
 											)}
-											{request.error && (
+											{request.summary?.errorMessage && (
 												<span className="text-sm text-destructive">
-													Error: {request.error}
+													Error: {request.summary.errorMessage}
 												</span>
 											)}
 										</div>
 										<div className="text-sm text-muted-foreground flex items-center gap-2">
-											{(summary?.responseTimeMs ||
-												request.meta.transport.pending) && (
+											{(summary?.responseTimeMs || request.pending) && (
 												<span>
 													{summary?.responseTimeMs
 														? formatDuration(summary.responseTimeMs)
 														: "--"}
 												</span>
 											)}
-											{request.meta.transport.retry !== undefined &&
-												request.meta.transport.retry > 0 && (
-													<span>Retry {request.meta.transport.retry}</span>
+											{summary?.failoverAttempts !== undefined &&
+												summary.failoverAttempts > 0 && (
+													<span>Retry {summary.failoverAttempts}</span>
 												)}
 											<span>ID: {request.id.slice(0, 8)}...</span>
 										</div>
@@ -540,7 +537,7 @@ export function RequestsTab() {
 										<Button
 											variant="ghost"
 											size="icon"
-											onClick={() => setModalRequest(request)}
+											onClick={() => setModalItem(request)}
 											title="View Details"
 										>
 											<Eye className="h-4 w-4" />
@@ -549,20 +546,21 @@ export function RequestsTab() {
 											variant="ghost"
 											size="icon"
 											title="Copy as JSON"
-											getValue={() => {
+											getValue={async () => {
+												const detail = await api.getRequestDetail(request.id);
 												const decoded: RequestPayload & { decoded?: true } = {
-													...request,
+													...detail,
 													request: {
-														...request.request,
-														body: request.request.body
-															? decodeBase64Body(request.request.body)
+														...detail.request,
+														body: detail.request.body
+															? decodeBase64Body(detail.request.body)
 															: null,
 													},
-													response: request.response
+													response: detail.response
 														? {
-																...request.response,
-																body: request.response.body
-																	? decodeBase64Body(request.response.body)
+																...detail.response,
+																body: detail.response.body
+																	? decodeBase64Body(detail.response.body)
 																	: null,
 															}
 														: null,
@@ -579,7 +577,7 @@ export function RequestsTab() {
 											<Button
 												variant="outline"
 												size="sm"
-												onClick={() => setModalRequest(request)}
+												onClick={() => setModalItem(request)}
 												className="w-full"
 											>
 												<Eye className="h-4 w-4 mr-2" />
@@ -594,12 +592,11 @@ export function RequestsTab() {
 				)}
 			</CardContent>
 
-			{modalRequest && (
+			{modalItem && (
 				<RequestDetailsModal
-					request={modalRequest}
-					summary={summaries.get(modalRequest.id)}
+					item={modalItem}
 					isOpen={true}
-					onClose={() => setModalRequest(null)}
+					onClose={() => setModalItem(null)}
 				/>
 			)}
 		</Card>

--- a/apps/web/src/hooks/useRequestsPageModel.ts
+++ b/apps/web/src/hooks/useRequestsPageModel.ts
@@ -1,43 +1,18 @@
 import type { AccountResponse } from "@ccflare/api";
-import {
-	parseRequestStreamEvent,
-	type RequestPayload,
-	type RequestSummary,
-} from "@ccflare/types";
+import { parseRequestStreamEvent } from "@ccflare/types";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { api } from "../api";
 import { REFRESH_INTERVALS } from "../constants";
 import { queryKeys } from "../lib/query-keys";
+import {
+	applyRequestStreamEvent,
+	filterRequestList,
+	type RequestListItem,
+	reconcileRequestList,
+} from "../lib/request-list-model";
 
-interface RequestsCache {
-	requests: RequestPayload[];
-	summaries: Map<string, RequestSummary>;
-}
-
-function upsertRequest(
-	requests: RequestPayload[],
-	id: string,
-	entry: RequestPayload,
-	limit: number,
-): RequestPayload[] {
-	const idx = requests.findIndex((r) => r.id === id);
-	return idx >= 0
-		? requests.map((r, i) => (i === idx ? entry : r))
-		: [entry, ...requests].slice(0, limit);
-}
-
-/**
- * Page-model hook for the Requests page.
- *
- * Owns:
- *  - initial fetch (polling as reconciliation, not primary)
- *  - SSE stream as primary freshness source
- *  - stable Map-based cache shape
- *  - account-name enrichment via SSE start events
- *
- * Components receive shaped data and call actions. No transport logic leaks.
- */
+/** Metadata-only page model for request history. Full payloads are fetched on demand. */
 export function useRequestsPageModel(limit = 200) {
 	const queryClient = useQueryClient();
 	const [accountFilter, setAccountFilter] = useState<string>("all");
@@ -47,32 +22,23 @@ export function useRequestsPageModel(limit = 200) {
 		new Set(),
 	);
 
-	// -- Base query: fetch + normalize into stable shape --
 	const {
 		data,
 		isLoading: loading,
 		error,
 		refetch,
-	} = useQuery<RequestsCache>({
+	} = useQuery<RequestListItem[]>({
 		queryKey: queryKeys.requests(limit),
-		queryFn: async (): Promise<RequestsCache> => {
-			const [detail, summary] = await Promise.all([
-				api.getRequestsDetail(limit),
-				api.getRequestsSummary(limit),
-			]);
-			// Always return a Map -- this is the stable shape.
-			const summaries = new Map<string, RequestSummary>();
-			for (const s of summary) {
-				summaries.set(s.id, s);
-			}
-			return { requests: detail, summaries };
+		queryFn: async () => {
+			const summaries = await api.getRequestsSummary(limit);
+			const current = queryClient.getQueryData<RequestListItem[]>(
+				queryKeys.requests(limit),
+			);
+			return reconcileRequestList(summaries, current, limit);
 		},
-		// Polling is a reconciliation path, not the primary source.
-		// SSE handles real-time freshness.
 		refetchInterval: REFRESH_INTERVALS.fast,
 	});
 
-	// -- SSE stream: patches the stable cache --
 	useEffect(() => {
 		let es: EventSource | null = null;
 		let isDisposed = false;
@@ -86,140 +52,34 @@ export function useRequestsPageModel(limit = 200) {
 			}
 
 			es = new EventSource("/api/requests/stream");
-
 			es.addEventListener("open", () => {
 				retries = 0;
 			});
-
 			es.addEventListener("message", (ev) => {
-				const evt = parseRequestStreamEvent(JSON.parse(ev.data));
-				if (!evt) return;
+				const event = parseRequestStreamEvent(JSON.parse(ev.data));
+				if (!event) return;
 
-				queryClient.setQueryData(
+				queryClient.setQueryData<RequestListItem[]>(
 					queryKeys.requests(limit),
-					(current: RequestsCache | undefined) => {
+					(current) => {
 						if (!current) return current;
-
-						const { requests, summaries } = current;
-
-						if (evt.type === "ingress") {
-							// If we already have data for this request, skip the placeholder
-							if (requests.some((r) => r.id === evt.id)) {
-								return current;
-							}
-
-							const placeholder: RequestPayload = {
-								id: evt.id,
-								request: { headers: {}, body: null },
-								response: null,
-								meta: {
-									trace: {
-										timestamp: evt.timestamp,
-										path: evt.path,
-										method: evt.method,
-									},
-									account: {
-										id: null,
-									},
-									transport: {
-										success: false,
-										pending: true,
-									},
-								},
-							};
-
-							return {
-								requests: [placeholder, ...requests].slice(0, limit),
-								summaries,
-							};
-						}
-
-						if (evt.type === "start") {
-							// Look up account name from cached accounts
+						let accountName: string | null = null;
+						if (event.type === "start") {
 							const accounts = queryClient.getQueryData<AccountResponse[]>(
 								queryKeys.accounts(),
 							);
-							const account = accounts?.find((a) => a.id === evt.accountId);
-
-							const placeholder: RequestPayload = {
-								id: evt.id,
-								request: { headers: {}, body: null },
-								response: {
-									status: evt.statusCode,
-									headers: {},
-									body: null,
-								},
-								meta: {
-									trace: {
-										timestamp: evt.timestamp,
-										path: evt.path,
-										method: evt.method,
-									},
-									account: {
-										id: evt.accountId,
-										name: account?.name,
-									},
-									transport: {
-										success: false,
-										pending: true,
-									},
-								},
-							};
-
-							return {
-								requests: upsertRequest(requests, evt.id, placeholder, limit),
-								summaries,
-							};
+							accountName =
+								accounts?.find((account) => account.id === event.accountId)
+									?.name ?? null;
 						}
-
-						if (evt.type === "payload") {
-							return {
-								requests: upsertRequest(
-									requests,
-									evt.payload.id,
-									evt.payload,
-									limit,
-								),
-								summaries,
-							};
-						}
-
-						// "summary" event
-						const newSummaries = new Map(summaries);
-						newSummaries.set(evt.payload.id, evt.payload);
-
-						// Clear pending status on the matching request
-						const reqIdx = requests.findIndex((r) => r.id === evt.payload.id);
-						if (reqIdx < 0) {
-							return { requests, summaries: newSummaries };
-						}
-
-						const newRequests = requests.map((r, i) => {
-							if (i !== reqIdx) return r;
-							return {
-								...r,
-								meta: {
-									...r.meta,
-									transport: {
-										...r.meta.transport,
-										pending: false,
-										success: evt.payload.success === true,
-									},
-								},
-							};
-						});
-
-						return { requests: newRequests, summaries: newSummaries };
+						return applyRequestStreamEvent(current, event, limit, accountName);
 					},
 				);
 			});
-
 			es.addEventListener("error", () => {
 				if (isDisposed) return;
-				if (es) {
-					es.close();
-					es = null;
-				}
+				es?.close();
+				es = null;
 				const delay = Math.min(1000 * 2 ** retries, 30000);
 				retries++;
 				reconnectTimeout = setTimeout(connect, delay);
@@ -227,108 +87,50 @@ export function useRequestsPageModel(limit = 200) {
 		};
 
 		connect();
-
 		return () => {
 			isDisposed = true;
 			if (reconnectTimeout) clearTimeout(reconnectTimeout);
-			if (es) es.close();
+			es?.close();
 		};
 	}, [limit, queryClient]);
 
-	const allRequests = data?.requests ?? [];
-	const summaries = data?.summaries ?? new Map<string, RequestSummary>();
+	const allRequests = data ?? [];
 	const uniqueAccounts = Array.from(
 		new Set(
 			allRequests
-				.map(
-					(request) =>
-						request.meta?.account?.name || request.meta?.account?.id || null,
-				)
+				.map((request) => request.accountName || request.accountId || null)
 				.filter(Boolean),
 		),
 	).sort();
 	const uniqueStatusCodes = Array.from(
 		new Set(
 			allRequests
-				.map((request) => request.response?.status)
-				.filter((status): status is number => status !== undefined),
+				.map((request) => request.statusCode)
+				.filter((status): status is number => status !== null),
 		),
 	).sort((left, right) => left - right);
-	const requests = allRequests.filter((request) => {
-		if (accountFilter !== "all") {
-			const requestAccount =
-				request.meta?.account?.name || request.meta?.account?.id;
-			if (requestAccount !== accountFilter) {
-				return false;
-			}
-		}
-
-		if (
-			statusCodeFilters.size > 0 &&
-			request.response?.status !== undefined &&
-			!statusCodeFilters.has(request.response.status.toString())
-		) {
-			return false;
-		}
-
-		const requestDate = new Date(request.meta.trace.timestamp);
-		if (dateFrom) {
-			const fromDate = new Date(dateFrom);
-			fromDate.setHours(0, 0, 0, 0);
-			if (requestDate < fromDate) {
-				return false;
-			}
-		}
-
-		if (dateTo) {
-			const toDate = new Date(dateTo);
-			toDate.setHours(23, 59, 59, 999);
-			if (requestDate > toDate) {
-				return false;
-			}
-		}
-
-		return true;
+	const requests = filterRequestList(allRequests, {
+		account: accountFilter,
+		dateFrom,
+		dateTo,
+		statusCodes: statusCodeFilters,
 	});
 
 	function applyDatePreset(preset: "1h" | "24h" | "7d" | "30d") {
 		const now = new Date();
-		const nextDateTo = now.toISOString().slice(0, 16);
-
-		switch (preset) {
-			case "1h": {
-				const fromDate = new Date(now.getTime() - 60 * 60 * 1000);
-				setDateFrom(fromDate.toISOString().slice(0, 16));
-				break;
-			}
-			case "24h": {
-				const fromDate = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-				setDateFrom(fromDate.toISOString().slice(0, 16));
-				break;
-			}
-			case "7d": {
-				const fromDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-				setDateFrom(fromDate.toISOString().slice(0, 16));
-				break;
-			}
-			case "30d": {
-				const fromDate = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-				setDateFrom(fromDate.toISOString().slice(0, 16));
-				break;
-			}
-		}
-
-		setDateTo(nextDateTo);
+		const hours = { "1h": 1, "24h": 24, "7d": 24 * 7, "30d": 24 * 30 }[preset];
+		setDateFrom(
+			new Date(now.getTime() - hours * 60 * 60 * 1000)
+				.toISOString()
+				.slice(0, 16),
+		);
+		setDateTo(now.toISOString().slice(0, 16));
 	}
 
 	function toggleStatusCode(code: string) {
 		setStatusCodeFilters((previous) => {
 			const next = new Set(previous);
-			if (next.has(code)) {
-				next.delete(code);
-			} else {
-				next.add(code);
-			}
+			next.has(code) ? next.delete(code) : next.add(code);
 			return next;
 		});
 	}
@@ -343,7 +145,6 @@ export function useRequestsPageModel(limit = 200) {
 	return {
 		requests,
 		allRequests,
-		summaries,
 		accountFilter,
 		setAccountFilter,
 		dateFrom,

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -15,6 +15,8 @@ export const queryKeys = {
 		] as const,
 	requests: (limit?: number) =>
 		[...queryKeys.all, "requests", { limit }] as const,
+	requestDetail: (requestId: string) =>
+		[...queryKeys.all, "request-detail", { requestId }] as const,
 	requestConversation: (requestId: string) =>
 		[...queryKeys.all, "request-conversation", { requestId }] as const,
 	logs: () => [...queryKeys.all, "logs"] as const,

--- a/apps/web/src/lib/request-list-model.test.ts
+++ b/apps/web/src/lib/request-list-model.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "bun:test";
+import type { RequestSummary } from "@ccflare/types";
+import {
+	applyRequestStreamEvent,
+	filterRequestList,
+	reconcileRequestList,
+} from "./request-list-model";
+
+function summary(
+	id: string,
+	overrides: Partial<RequestSummary> = {},
+): RequestSummary {
+	return {
+		id,
+		timestamp: new Date(1_000).toISOString(),
+		method: "POST",
+		path: "/v1/openai/responses",
+		provider: "openai",
+		upstreamPath: "/responses",
+		accountUsed: "account-1",
+		accountName: "Primary",
+		statusCode: 200,
+		success: true,
+		errorMessage: null,
+		responseTimeMs: 20,
+		failoverAttempts: 0,
+		model: "gpt-test",
+		promptTokens: 10,
+		completionTokens: 5,
+		totalTokens: 15,
+		inputTokens: 10,
+		cacheReadInputTokens: 0,
+		cacheCreationInputTokens: 0,
+		outputTokens: 5,
+		reasoningTokens: 0,
+		costUsd: 0.01,
+		tokensPerSecond: 2,
+		ttftMs: 4,
+		proxyOverheadMs: 1,
+		upstreamTtfbMs: 3,
+		streamingDurationMs: 10,
+		responseId: null,
+		previousResponseId: null,
+		responseChainId: null,
+		clientSessionId: null,
+		...overrides,
+	};
+}
+
+describe("request list model", () => {
+	it("reconciles summaries while preserving pending rows without payloads", () => {
+		const pending = applyRequestStreamEvent(
+			[],
+			{
+				type: "ingress",
+				id: "pending",
+				timestamp: 2_000,
+				method: "POST",
+				path: "/pending",
+			},
+			2,
+		);
+		const reconciled = reconcileRequestList(
+			[summary("stored", { timestamp: new Date(1_500).toISOString() })],
+			pending,
+			2,
+		);
+
+		expect(reconciled.map((item) => item.id)).toEqual(["pending", "stored"]);
+		expect(JSON.stringify(reconciled)).not.toContain('request":');
+		expect(JSON.stringify(reconciled)).not.toContain('response":');
+	});
+
+	it("applies start and summary events as metadata only", () => {
+		let items = applyRequestStreamEvent(
+			[],
+			{
+				type: "ingress",
+				id: "live",
+				timestamp: 1_000,
+				method: "POST",
+				path: "/live",
+			},
+			200,
+		);
+		items = applyRequestStreamEvent(
+			items,
+			{
+				type: "start",
+				id: "live",
+				timestamp: 1_000,
+				method: "POST",
+				path: "/live",
+				accountId: "account-2",
+				statusCode: 202,
+			},
+			200,
+			"Secondary",
+		);
+		expect(items[0]).toMatchObject({
+			pending: true,
+			accountName: "Secondary",
+			statusCode: 202,
+		});
+
+		items = applyRequestStreamEvent(
+			items,
+			{ type: "summary", payload: summary("live", { success: false }) },
+			200,
+		);
+		expect(items[0]).toMatchObject({
+			pending: false,
+			summary: { success: false },
+		});
+		expect(JSON.stringify(items)).not.toContain("headers");
+		expect(JSON.stringify(items)).not.toContain("body");
+	});
+
+	it("preserves account, status, and date filtering", () => {
+		const items = reconcileRequestList(
+			[
+				summary("match", { timestamp: "2026-08-01T12:00:00.000Z" }),
+				summary("other", {
+					timestamp: "2026-07-30T12:00:00.000Z",
+					accountName: "Secondary",
+					statusCode: 500,
+				}),
+			],
+			[],
+			200,
+		);
+		expect(
+			filterRequestList(items, {
+				account: "Primary",
+				dateFrom: "2026-08-01",
+				dateTo: "2026-08-01",
+				statusCodes: new Set(["200"]),
+			}).map((item) => item.id),
+		).toEqual(["match"]);
+	});
+});

--- a/apps/web/src/lib/request-list-model.ts
+++ b/apps/web/src/lib/request-list-model.ts
@@ -1,0 +1,124 @@
+import type {
+	HttpMethod,
+	RequestStreamEvent,
+	RequestSummary,
+} from "@ccflare/types";
+
+/** Metadata retained by the request-history list. Payload headers and bodies never enter this model. */
+export interface RequestListItem {
+	id: string;
+	timestamp: number;
+	method: HttpMethod;
+	path: string;
+	accountId: string | null;
+	accountName: string | null;
+	statusCode: number | null;
+	pending: boolean;
+	summary: RequestSummary | null;
+}
+
+export interface RequestListFilters {
+	account: string;
+	dateFrom: string;
+	dateTo: string;
+	statusCodes: Set<string>;
+}
+
+export function requestListItemFromSummary(
+	summary: RequestSummary,
+): RequestListItem {
+	return {
+		id: summary.id,
+		timestamp: Date.parse(summary.timestamp),
+		method: summary.method,
+		path: summary.path,
+		accountId: summary.accountUsed,
+		accountName: summary.accountName,
+		statusCode: summary.statusCode,
+		pending: summary.success === null,
+		summary,
+	};
+}
+
+export function reconcileRequestList(
+	summaries: RequestSummary[],
+	current: RequestListItem[] = [],
+	limit: number,
+): RequestListItem[] {
+	const summaryIds = new Set(summaries.map((summary) => summary.id));
+	const pending = current.filter(
+		(item) => item.pending && !summaryIds.has(item.id),
+	);
+	return [...summaries.map(requestListItemFromSummary), ...pending]
+		.sort((left, right) => right.timestamp - left.timestamp)
+		.slice(0, limit);
+}
+
+export function applyRequestStreamEvent(
+	items: RequestListItem[],
+	event: RequestStreamEvent,
+	limit: number,
+	accountName: string | null = null,
+): RequestListItem[] {
+	if (event.type === "summary") {
+		const completed = requestListItemFromSummary(event.payload);
+		const existingIndex = items.findIndex((item) => item.id === completed.id);
+		if (existingIndex < 0) return [completed, ...items].slice(0, limit);
+		return items.map((item, index) =>
+			index === existingIndex ? completed : item,
+		);
+	}
+
+	const existing = items.find((item) => item.id === event.id);
+	const item: RequestListItem = {
+		id: event.id,
+		timestamp: event.timestamp,
+		method: event.method,
+		path: event.path,
+		accountId: event.type === "start" ? event.accountId : null,
+		accountName: event.type === "start" ? accountName : null,
+		statusCode: event.type === "start" ? event.statusCode : null,
+		pending: true,
+		summary: null,
+	};
+
+	if (!existing) return [item, ...items].slice(0, limit);
+	if (event.type === "ingress") return items;
+	return items.map((current) =>
+		current.id === event.id ? { ...current, ...item } : current,
+	);
+}
+
+export function filterRequestList(
+	items: RequestListItem[],
+	filters: RequestListFilters,
+): RequestListItem[] {
+	return items.filter((item) => {
+		if (
+			filters.account !== "all" &&
+			(item.accountName || item.accountId) !== filters.account
+		) {
+			return false;
+		}
+		if (
+			filters.statusCodes.size > 0 &&
+			item.statusCode !== null &&
+			!filters.statusCodes.has(item.statusCode.toString())
+		) {
+			return false;
+		}
+
+		const requestDate = new Date(item.timestamp);
+		if (filters.dateFrom) {
+			const fromDate = new Date(filters.dateFrom);
+			fromDate.setHours(0, 0, 0, 0);
+			if (requestDate < fromDate) return false;
+		}
+		if (filters.dateTo) {
+			const toDate = new Date(filters.dateTo);
+			toDate.setHours(23, 59, 59, 999);
+			if (requestDate > toDate) return false;
+		}
+		return true;
+	});
+}

--- a/docs/api-http.md
+++ b/docs/api-http.md
@@ -484,56 +484,50 @@ Get recent request summary.
 curl "http://localhost:8080/api/requests?limit=100"
 ```
 
-#### GET /api/requests/detail
+#### GET /api/requests/:requestId/detail
 
-Get detailed request information including payloads. Request and response bodies are base64-encoded to handle binary data and special characters.
-
-**Query Parameters:**
-- `limit` - Number of requests to return (default: 100)
+Get detailed request information for one exact stored request ID. Request and response bodies are base64-encoded to handle binary data and special characters. Unknown IDs return `404`; records without a stored payload return a metadata-only fallback.
 
 **Response:**
 ```json
-[
-  {
-    "id": "request-uuid",
-    "timestamp": "2024-12-17T10:30:45.123Z",
-    "method": "POST",
-    "path": "/v1/anthropic/v1/messages",
-    "accountUsed": "account1",
-    "statusCode": 200,
-    "success": true,
-    "payload": {
-      "request": {
-        "headers": {...},
-        "body": "base64-encoded-body"
-      },
-      "response": {
-        "status": 200,
-        "headers": {...},
-        "body": "base64-encoded-body"
-      },
-      "meta": {
-        "accountId": "uuid",
-        "accountName": "account1",
-        "retry": 0,
-        "timestamp": 1234567890,
-        "success": true,
-        "rateLimited": false,
-        "accountsAttempted": 1
-      }
+{
+  "id": "request-uuid",
+  "request": {
+    "headers": {...},
+    "body": "base64-encoded-body"
+  },
+  "response": {
+    "status": 200,
+    "headers": {...},
+    "body": "base64-encoded-body"
+  },
+  "meta": {
+    "trace": {
+      "timestamp": 1234567890,
+      "method": "POST",
+      "path": "/v1/anthropic/v1/messages"
+    },
+    "account": {
+      "id": "uuid",
+      "name": "account1"
+    },
+    "transport": {
+      "success": true,
+      "pending": false,
+      "retry": 0
     }
   }
-]
+}
 ```
 
 **Example:**
 ```bash
-curl "http://localhost:8080/api/requests/detail?limit=10"
+curl "http://localhost:8080/api/requests/request-uuid/detail"
 ```
 
 #### GET /api/requests/stream
 
-Stream real-time request events via Server-Sent Events (SSE).
+Stream metadata-only real-time request events via Server-Sent Events (SSE). The stream emits ingress, start, and completed summary events; it never includes stored request or response bodies.
 
 **Response:** SSE stream with request events
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -123,9 +123,9 @@ For HTTP proxy traffic:
 
 For streaming and websocket traffic:
 
-- the proxy emits chunk/summary payloads to the worker
+- the proxy emits response chunks and completion metadata to the worker
 - the worker parses provider-specific usage events
-- final summaries and payloads are persisted asynchronously
+- full payloads are persisted asynchronously, while only final summaries return to the main thread and request-summary SSE stream
 
 ## Event Streaming
 

--- a/packages/api/src/handlers/requests.ts
+++ b/packages/api/src/handlers/requests.ts
@@ -1,4 +1,4 @@
-import type { DatabaseOperations } from "@ccflare/database";
+import type { DatabaseOperations, RequestDetailRow } from "@ccflare/database";
 import {
 	errorResponse,
 	InternalServerError,
@@ -6,7 +6,12 @@ import {
 	NotFound,
 } from "@ccflare/http";
 import { Logger } from "@ccflare/logger";
-import { parseRequestPayload } from "@ccflare/types";
+import {
+	isAccountProvider,
+	isHttpMethod,
+	parseRequestPayload,
+	type RequestPayload,
+} from "@ccflare/types";
 import {
 	enrichRequestPayload,
 	serializeRequestResponse,
@@ -41,6 +46,59 @@ function parsePayloadRows(
 	});
 }
 
+function parseDetailRow(row: RequestDetailRow): RequestPayload | null {
+	if (!isHttpMethod(row.method) || !isAccountProvider(row.provider)) {
+		return null;
+	}
+	if (row.payload_json) {
+		try {
+			const payload = parseRequestPayload({
+				...JSON.parse(row.payload_json),
+				id: row.id,
+			});
+			if (payload) {
+				return enrichRequestPayload(payload, row.account_name);
+			}
+		} catch {
+			log.warn(`Falling back to summary payload for ${row.id}`);
+		}
+	}
+
+	return {
+		id: row.id,
+		request: { headers: {}, body: null },
+		response:
+			row.status_code === null
+				? null
+				: { status: row.status_code, headers: {}, body: null },
+		...(row.error_message ? { error: row.error_message } : {}),
+		meta: {
+			trace: {
+				timestamp: row.timestamp,
+				method: row.method,
+				path: row.path,
+				provider: row.provider,
+				upstreamPath: row.upstream_path,
+				responseId: row.response_id,
+				previousResponseId: row.previous_response_id,
+				responseChainId: row.response_chain_id,
+				clientSessionId: row.client_session_id,
+			},
+			account: { id: row.account_used, name: row.account_name },
+			transport: {
+				success: row.success === 1,
+				pending: row.success === null,
+				retry: row.failover_attempts,
+				isStream: row.method === "WS",
+				ttftMs: row.ttft_ms,
+				proxyOverheadMs: row.proxy_overhead_ms,
+				upstreamTtfbMs: row.upstream_ttfb_ms,
+				streamingDurationMs: row.streaming_duration_ms,
+			},
+		},
+	};
+}
+
 /**
  * Create a requests summary handler (existing functionality)
  */
@@ -63,11 +121,17 @@ export function createRequestsSummaryHandler(dbOps: DatabaseOperations) {
  * Create a detailed requests handler with full payload data
  */
 export function createRequestsDetailHandler(dbOps: DatabaseOperations) {
-	return (limit = 100): Response => {
+	return (requestId: string): Response => {
 		try {
-			return jsonResponse(
-				parsePayloadRows(dbOps.listRequestPayloadsWithAccountNames(limit)),
-			);
+			const row = dbOps.getRequestDetailRow(requestId);
+			if (!row) {
+				return errorResponse(NotFound("Request detail not found"));
+			}
+			const payload = parseDetailRow(row);
+			if (!payload) {
+				return errorResponse(InternalServerError("Invalid request metadata"));
+			}
+			return jsonResponse(payload);
 		} catch (error) {
 			log.error("Failed to load request details", error);
 			return errorResponse(

--- a/packages/api/src/router.test.ts
+++ b/packages/api/src/router.test.ts
@@ -874,7 +874,7 @@ describe("APIRouter", () => {
 		]);
 	});
 
-	it("returns structured request payload metadata sections", async () => {
+	it("keeps large payloads out of summaries and returns one exact detail", async () => {
 		const { router, dbOps } = createRouterContext();
 		const { accountId } = await createApiKeyAccount(router, {
 			name: "payload-owner",
@@ -893,9 +893,10 @@ describe("APIRouter", () => {
 			21,
 			0,
 		);
+		const sentinel = `sentinel-${"x".repeat(3 * 1024 * 1024)}`;
 		dbOps.saveRequestPayload("request-payload", {
 			id: "request-payload",
-			request: { headers: {}, body: null },
+			request: { headers: {}, body: sentinel },
 			response: { status: 200, headers: {}, body: null },
 			meta: {
 				trace: {
@@ -916,13 +917,24 @@ describe("APIRouter", () => {
 			},
 		});
 
+		const summaryResponse = await apiRequest(
+			router,
+			"GET",
+			"/api/requests?limit=200",
+		);
+		const summaryText = await summaryResponse.text();
+		expect(summaryResponse.status).toBe(200);
+		expect(summaryText).not.toContain("sentinel-");
+
 		const response = await apiRequest(
 			router,
 			"GET",
-			"/api/requests/detail?limit=1",
+			"/api/requests/request-payload/detail",
 		);
 		expect(response.status).toBe(200);
-		expect((await response.json()) as Array<Record<string, unknown>>).toEqual([
+		const detailText = await response.text();
+		expect(detailText).toContain(sentinel);
+		expect(JSON.parse(detailText) as Record<string, unknown>).toEqual(
 			expect.objectContaining({
 				id: "request-payload",
 				meta: {
@@ -944,7 +956,13 @@ describe("APIRouter", () => {
 					},
 				},
 			}),
-		]);
+		);
+		expect(
+			(await apiRequest(router, "GET", "/api/requests/unknown/detail")).status,
+		).toBe(404);
+		expect(
+			(await apiRequest(router, "GET", "/api/requests/detail?limit=1")).status,
+		).toBe(404);
 	});
 
 	it("returns the conversation ancestor chain for a request", async () => {

--- a/packages/api/src/router.ts
+++ b/packages/api/src/router.ts
@@ -137,16 +137,11 @@ export class APIRouter {
 				}) || 50;
 			return requestsSummaryHandler(limit);
 		});
-		this.staticHandlers.set("GET:/api/requests/detail", (_req, url) => {
-			const limitParam = url.searchParams.get("limit");
-			const limit =
-				validateNumber(limitParam || "100", "limit", {
-					min: 1,
-					max: 1000,
-					integer: true,
-				}) || 100;
-			return requestsDetailHandler(limit);
-		});
+		this.addDynamicRoute(
+			"GET",
+			"/api/requests/:requestId/detail",
+			(_req, _url, params) => requestsDetailHandler(params.requestId),
+		);
 		this.addDynamicRoute(
 			"GET",
 			"/api/requests/:requestId/conversation",

--- a/packages/database/src/database-operations.test.ts
+++ b/packages/database/src/database-operations.test.ts
@@ -93,6 +93,41 @@ describe("DatabaseOperations", () => {
 		}
 	});
 
+	it("loads one request detail row by exact stored id", () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "ccflare-db-ops-"));
+		tempDirs.push(tempDir);
+		const dbOps = new DatabaseOperations(join(tempDir, "ccflare.db"));
+
+		try {
+			for (const id of ["selected", "other"]) {
+				dbOps.saveRequestMeta(
+					id,
+					"POST",
+					`/${id}`,
+					"openai",
+					`/${id}`,
+					null,
+					200,
+				);
+				dbOps.saveRequestPayload(id, {
+					id,
+					request: { headers: {}, body: `${id}-body` },
+				});
+			}
+
+			expect(dbOps.getRequestDetailRow("selected")).toMatchObject({
+				id: "selected",
+				payload_json: expect.stringContaining("selected-body"),
+			});
+			expect(dbOps.getRequestDetailRow("selected")?.payload_json).not.toContain(
+				"other-body",
+			);
+			expect(dbOps.getRequestDetailRow("missing")).toBeNull();
+		} finally {
+			dbOps.close();
+		}
+	});
+
 	it("aggregates analytics through the repository facade", () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "ccflare-db-ops-"));
 		tempDirs.push(tempDir);

--- a/packages/database/src/database-operations.ts
+++ b/packages/database/src/database-operations.ts
@@ -27,6 +27,7 @@ import {
 import { AuthSessionRepository } from "./repositories/auth-session.repository";
 import {
 	type RequestData,
+	type RequestDetailRow,
 	RequestRepository,
 } from "./repositories/request.repository";
 import { StatsRepository } from "./repositories/stats.repository";
@@ -287,6 +288,10 @@ export class DatabaseOperations implements StrategyStore, Disposable {
 		limit = 50,
 	): Array<{ id: string; json: string; account_name: string | null }> {
 		return this.requests.listPayloadsWithAccountNames(limit);
+	}
+
+	getRequestDetailRow(requestId: string): RequestDetailRow | null {
+		return this.requests.findDetailRow(requestId);
 	}
 
 	listResponseChainPayloadsWithAccountNames(

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -12,3 +12,4 @@ export { type AccountRow, toAccount } from "./models/account-row";
 export { type RequestRow, toRequest } from "./models/request-row";
 export { resolveDbPath } from "./paths";
 export { analyzeIndexUsage } from "./performance-indexes";
+export type { RequestDetailRow } from "./repositories/request.repository";

--- a/packages/database/src/repositories/request.repository.ts
+++ b/packages/database/src/repositories/request.repository.ts
@@ -51,6 +51,11 @@ export interface RequestData {
 	};
 }
 
+export interface RequestDetailRow extends RequestRow {
+	account_name: string | null;
+	payload_json: string | null;
+}
+
 interface PersistRequestData extends RequestData {
 	timestamp?: number;
 	payload?: unknown;
@@ -295,6 +300,19 @@ export class RequestRepository extends BaseRepository<RequestData> {
 			log.warn(`Failed to parse request payload for ${id}`, error);
 			return null;
 		}
+	}
+
+	findDetailRow(requestId: string): RequestDetailRow | null {
+		return this.get<RequestDetailRow>(
+			`
+				SELECT r.*, a.name AS account_name, rp.json AS payload_json
+				FROM requests r
+				LEFT JOIN accounts a ON r.account_used = a.id
+				LEFT JOIN request_payloads rp ON rp.id = r.id
+				WHERE r.id = ?
+			`,
+			[requestId],
+		);
 	}
 
 	listPayloads(limit = 50): Array<{ id: string; json: string }> {

--- a/packages/proxy/src/post-processor.worker.ts
+++ b/packages/proxy/src/post-processor.worker.ts
@@ -32,13 +32,13 @@ import type {
 	ChunkMessage,
 	EndMessage,
 	IncomingWorkerMessage,
-	PayloadMessage,
 	PreExtractedUsage,
 	ReadyMessage,
 	ShutdownCompleteMessage,
 	StartMessage,
 	SummaryMessage,
 } from "./worker-messages";
+import { createCompletionMessages } from "./worker-messages";
 
 interface RequestState {
 	startMessage: StartMessage;
@@ -861,15 +861,9 @@ async function handleEnd(msg: EndMessage): Promise<void> {
 		clientSessionId,
 	};
 
-	self.postMessage({
-		type: "summary",
-		summary,
-	} satisfies SummaryMessage);
-
-	self.postMessage({
-		type: "payload",
-		payload: { ...payload, error: msg.error },
-	} satisfies PayloadMessage);
+	for (const message of createCompletionMessages(summary)) {
+		self.postMessage(message satisfies SummaryMessage);
+	}
 
 	// Clean up
 	requests.delete(msg.requestId);

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1,6 +1,6 @@
 import { requestEvents, ServiceUnavailableError } from "@ccflare/core";
 import { Logger } from "@ccflare/logger";
-import { isRequestPayload, isRequestSummary } from "@ccflare/types";
+import { isRequestSummary } from "@ccflare/types";
 import {
 	createRequestMetadata,
 	ERROR_MESSAGES,
@@ -43,11 +43,6 @@ export function getUsageWorker(): UsageWorkerTransport {
 					requestEvents.emit("event", {
 						type: "summary",
 						payload: data.summary,
-					});
-				} else if (data.type === "payload" && isRequestPayload(data.payload)) {
-					requestEvents.emit("event", {
-						type: "payload",
-						payload: data.payload,
 					});
 				}
 			},

--- a/packages/proxy/src/worker-messages.test.ts
+++ b/packages/proxy/src/worker-messages.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import type { RequestSummary } from "@ccflare/types";
+import { createCompletionMessages } from "./worker-messages";
+
+describe("completion worker messages", () => {
+	it("returns only a summary message to the main thread", () => {
+		const summary = { id: "request-1" } as RequestSummary;
+
+		expect(createCompletionMessages(summary)).toEqual([
+			{ type: "summary", summary },
+		]);
+	});
+});

--- a/packages/proxy/src/worker-messages.ts
+++ b/packages/proxy/src/worker-messages.ts
@@ -100,14 +100,14 @@ export interface SummaryMessage {
 	summary: import("@ccflare/types").RequestSummary;
 }
 
-export interface PayloadMessage {
-	type: "payload";
-	payload: import("@ccflare/types").RequestPayload;
+export function createCompletionMessages(
+	summary: import("@ccflare/types").RequestSummary,
+): SummaryMessage[] {
+	return [{ type: "summary", summary }];
 }
 
 export type OutgoingWorkerMessage =
 	| SummaryMessage
-	| PayloadMessage
 	| ReadyMessage
 	| AckMessage
 	| ShutdownCompleteMessage;

--- a/packages/types/src/request-events.ts
+++ b/packages/types/src/request-events.ts
@@ -2,9 +2,7 @@ import { isFiniteNumber, isRecord } from "./guards";
 import {
 	type HttpMethod,
 	isHttpMethod,
-	isRequestPayload,
 	isRequestSummary,
-	type RequestPayload,
 	type RequestSummary,
 } from "./request";
 
@@ -31,16 +29,10 @@ export interface RequestSummaryEvent {
 	payload: RequestSummary;
 }
 
-export interface RequestPayloadEvent {
-	type: "payload";
-	payload: RequestPayload;
-}
-
 export type RequestStreamEvent =
 	| RequestIngressEvent
 	| RequestStartEvent
-	| RequestSummaryEvent
-	| RequestPayloadEvent;
+	| RequestSummaryEvent;
 
 export function isRequestStreamEvent(
 	value: unknown,
@@ -70,8 +62,6 @@ export function isRequestStreamEvent(
 			);
 		case "summary":
 			return isRequestSummary(value.payload);
-		case "payload":
-			return isRequestPayload(value.payload);
 		default:
 			return false;
 	}

--- a/packages/types/src/stream-events.test.ts
+++ b/packages/types/src/stream-events.test.ts
@@ -139,6 +139,24 @@ describe("stream event validation", () => {
 		});
 	});
 
+	it("rejects full-payload request events", () => {
+		expect(
+			parseRequestStreamEvent({
+				type: "payload",
+				payload: {
+					id: "request-payload",
+					request: { headers: {}, body: "large-body" },
+					response: null,
+					meta: {
+						trace: { timestamp: 123 },
+						account: { id: null },
+						transport: {},
+					},
+				},
+			}),
+		).toBeNull();
+	});
+
 	it("parses validated log stream payloads", () => {
 		expect(parseLogStreamEvent({ connected: true })).toEqual({
 			connected: true,

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -68,6 +68,5 @@ export const QUERY_CONFIG = {
 } as const;
 
 export const API_LIMITS = {
-	requestsDetail: 100,
 	requestsSummary: 50,
 } as const;


### PR DESCRIPTION
The /requests page was a real performance hog, constantly eager-reloading 200 requests at a time, which caused significant strain over time. I had 5.6-sol rewrite it to be lazy-loading instead, it should be a minimal-impact improvement if you merge it.

### Performance Numbers

The /requests page refreshes every 10 seconds and displays up to 200 rows. Previously, each refresh loaded all stored request and response bodies, although the table only needs metadata.

For 0.8 MiB payloads (my average), this could transfer 152 MiB of unnecessary data per refresh—15 MiB/s or 53 GiB/hour while the page remained open. The new implementation loads only metadata and fetches a payload when the user opens or copies that request. It also removes redundant full-payload transfers between the worker, server, and connected dashboards.